### PR TITLE
Duplicate not selector in hover mixin

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -47,7 +47,7 @@
 }
 
 @mixin oFtButtonsButtonHover($buttonClass, $borderColor, $backgroundColor, $color) {
-  &:not([disabled]):not([disabled]):not([aria-selected=true]):not(#{#{$buttonClass}--faux}):hover {
+  &:not([disabled]):not([aria-selected=true]):not(#{#{$buttonClass}--faux}):hover {
     @include oFtButtonsColors($borderColor, $backgroundColor, $color);
     cursor: pointer;
   }


### PR DESCRIPTION
Just spotted this typo causing a redundant :not([disabled]) selector for buttons
