### PR TITLE
Fix standard standout colors

### DIFF
--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -41,11 +41,10 @@ $o-buttons-themes__standard: (
 ) !default;
 
 @include oColorsSetUseCase(o-buttons-standout-normal,   text,              'white');
-@include oColorsSetUseCase(o-buttons-standout-normal,   background,        'link-2');
-@include oColorsSetUseCase(o-buttons-standout-normal,   border,            'link-2');
-@include oColorsSetUseCase(o-buttons-standout-hover,    background,        'link-1');
-@include oColorsSetUseCase(o-buttons-standout-pressedselected, background, 'link-1');
-@include oColorsSetUseCase(o-buttons-standout-pressedselected, text,       'white');
+@include oColorsSetUseCase(o-buttons-standout-normal,   background,        'link-1');
+@include oColorsSetUseCase(o-buttons-standout-hover,    border,            'link-2');
+@include oColorsSetUseCase(o-buttons-standout-pressedselected, background, 'link-2');
+@include oColorsSetUseCase(o-buttons-standout-pressedselected, text,       'cold-3');
 
 /// Theme: Standout
 ///
@@ -54,14 +53,16 @@ $o-buttons-themes__standout: (
 	normal: (
 		color: oColorsGetColorFor(o-buttons-standout-normal, text),
 		background: oColorsGetColorFor(o-buttons-standout-normal, background),
-		border-color: oColorsGetColorFor(o-buttons-standout-normal, border),
+		border-color: oColorsGetColorFor(o-buttons-standout-normal, background),
 		text-transform: uppercase,
 	),
 	active: (
-		color: mix(oColorsGetColorFor(o-buttons-standout-normal, text), oColorsGetColorFor(o-buttons-standout-hover, background), 80),
+		color: darken(oColorsGetColorFor(o-buttons-standout-normal, text), 20%),
 	),
 	hover: (
-		background: oColorsGetColorFor(o-buttons-standout-hover, background),
+		color: oColorsGetColorFor(o-buttons-standout-normal, text),
+		background: lighten(oColorsGetColorFor(o-buttons-standout-normal, background), 3.7%),
+		border-color: oColorsGetColorFor(o-buttons-standout-hover, border),
 	),
 	pressedselected: (
 		color: oColorsGetColorFor(o-buttons-standout-pressedselected, text),


### PR DESCRIPTION
The standard standout color was failing [contrast ratio test](http://leaverou.github.io/contrast-ratio/#%23fff-on-%232bbbbf)s.

Now the default state is [link-1](https://next.ft.com/__styleguide/design-primitives#palette)—[which passes with white text](http://leaverou.github.io/contrast-ratio/#%23fff-on-%2327757b), and a slightly lighter color for hover (by 3.7%: just enough to [pass the 4.5:1 contrast ratio](http://leaverou.github.io/contrast-ratio/#%23fff-on-%232c8389)).

![standout-buttons](https://cloud.githubusercontent.com/assets/150157/8599034/0b2ecd7c-2656-11e5-96e2-bd0a8dfc8309.gif)

We'll work on the pressed/selected states soon, as they're obviously a bit weird but we're not using them in Next yet.