### PR TITLE
Widen semver range for o-ft-icons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,6 @@
 	"dependencies": {
 		"o-colors": "^3.1.0",
 		"o-hoverable": ">=0.1.1 <4",
-		"o-ft-icons": "^3.3.0"
+		"o-ft-icons": "^3.3.0 || ^2.4.1"
 	}
 }


### PR DESCRIPTION
Since introducing the o-ft-icons dependency at v3.3.0 we've seen some conflicts
for bundles that were working previously. We've now released a change to v2.x.x
of o-ft-icons allowing us to widen the semver range here meaning the conflict
can be resolved.

This patch uses the double pipe to say either 3.3.0 and up, or 2.4.1 and up of o-ft-icons