### PR TITLE
Remove text-transform: uppercase;

### DIFF
--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -56,7 +56,6 @@ $o-buttons-themes__standout: (
 		color: oColorsGetColorFor(o-buttons-standout-normal, text),
 		background-color: oColorsGetColorFor(o-buttons-standout-normal, background),
 		border-color: oColorsGetColorFor(o-buttons-standout-normal, background),
-		text-transform: uppercase,
 	),
 	active: (
 		color: darken(oColorsGetColorFor(o-buttons-standout-normal, text), 20%),


### PR DESCRIPTION
As per with [Financial-Times/ft-origami/issues/492](https://github.com/Financial-Times/ft-origami/issues/492).