### PR TITLE
Remove icon examples from demos

### DIFF
--- a/demos/src/individual-inverse.mustache
+++ b/demos/src/individual-inverse.mustache
@@ -18,11 +18,3 @@
 <button class="o-buttons o-buttons--inverse o-buttons--big" aria-selected="true">Selected</button>
 <button class="o-buttons o-buttons--inverse o-buttons--big" aria-pressed="true">Pressed</button>
 <button class="o-buttons o-buttons--inverse o-buttons--big" disabled="disabled">Disabled</button>
-
-<br />
-<br />
-
-<button class="o-buttons o-buttons--inverse o-buttons-icon o-buttons-icon--icon-only o-buttons-icon--arrow-left"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--inverse o-buttons-icon o-buttons-icon--icon-only o-buttons-icon--arrow-left" aria-selected="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--inverse o-buttons-icon o-buttons-icon--icon-only o-buttons-icon--arrow-left" aria-pressed="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--inverse o-buttons-icon o-buttons-icon--icon-only o-buttons-icon--arrow-left" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>

--- a/demos/src/individual-standout.mustache
+++ b/demos/src/individual-standout.mustache
@@ -18,11 +18,3 @@
 <button class="o-buttons o-buttons--standout o-buttons--big" aria-selected="true">Selected</button>
 <button class="o-buttons o-buttons--standout o-buttons--big" aria-pressed="true">Pressed</button>
 <button class="o-buttons o-buttons--standout o-buttons--big" disabled="disabled">Disabled</button>
-
-<br />
-<br />
-
-<button class="o-buttons o-buttons--standout o-buttons--big o-buttons-icon--icon-only o-buttons-icon o-buttons-icon--arrow-left"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--standout o-buttons--big o-buttons-icon--icon-only o-buttons-icon o-buttons-icon--arrow-left" aria-selected="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--standout o-buttons--big o-buttons-icon--icon-only o-buttons-icon o-buttons-icon--arrow-left" aria-pressed="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--standout o-buttons--big o-buttons-icon--icon-only o-buttons-icon o-buttons-icon--arrow-left" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>

--- a/demos/src/individual-uncolored.mustache
+++ b/demos/src/individual-uncolored.mustache
@@ -6,26 +6,10 @@
 <br />
 <br />
 
-<button class="o-buttons o-buttons--small o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--small o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-selected="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--small o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-pressed="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--small o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>
-
-<br />
-<br />
-
 <button class="o-buttons o-buttons--uncolored">Standard</button>
 <button class="o-buttons o-buttons--uncolored" aria-selected="true">Selected</button>
 <button class="o-buttons o-buttons--uncolored" aria-pressed="true">Pressed</button>
 <button class="o-buttons o-buttons--uncolored" disabled="disabled">Disabled</button>
-
-
-<br />
-<br />
-
-<button class="o-buttons o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-pressed="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>
 
 <br />
 <br />
@@ -34,11 +18,3 @@
 <button class="o-buttons o-buttons--uncolored o-buttons--big" aria-selected="true">Selected</button>
 <button class="o-buttons o-buttons--uncolored o-buttons--big" aria-pressed="true">Pressed</button>
 <button class="o-buttons o-buttons--uncolored o-buttons--big" disabled="disabled">Disabled</button>
-
-<br />
-<br />
-
-<button class="o-buttons o-buttons--big o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--big o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-selected="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--big o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-pressed="true"><span class='o-buttons-icon__label'>Fewer results</span></button>
-<button class="o-buttons o-buttons--big o-buttons--uncolored o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>

--- a/demos/src/individual.mustache
+++ b/demos/src/individual.mustache
@@ -6,15 +6,6 @@
 <br />
 <br />
 
-<button class="o-buttons o-buttons--small o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"></button>
-<button class="o-buttons o-buttons--small o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-selected="true"></button>
-<button class="o-buttons o-buttons--small o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-pressed="true"></button>
-<button class="o-buttons o-buttons--small o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"></button>
-
-
-<br />
-<br />
-
 <button class="o-buttons">Standard</button>
 <button class="o-buttons" aria-selected="true">Selected</button>
 <button class="o-buttons" aria-pressed="true">Pressed</button>
@@ -23,24 +14,7 @@
 <br />
 <br />
 
-<button class="o-buttons o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"></button>
-<button class="o-buttons o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-selected="true"></button>
-<button class="o-buttons o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-pressed="true"></button>
-<button class="o-buttons o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"></button>
-
-
-<br />
-<br />
-
 <button class="o-buttons o-buttons--big">Standard</button>
 <button class="o-buttons o-buttons--big" aria-selected="true">Selected</button>
 <button class="o-buttons o-buttons--big" aria-pressed="true">Pressed</button>
 <button class="o-buttons o-buttons--big" disabled="disabled">Disabled</button>
-
-<br />
-<br />
-
-<button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"></button>
-<button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-selected="true"></button>
-<button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" aria-pressed="true"></button>
-<button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"></button>


### PR DESCRIPTION
Has been requested in: https://github.com/Financial-Times/ft-origami/issues/493

The demo page for icons only has been left, but icon button examples have been removed from the remaining themes.