### PR TITLE
Next Style Guide colours added

### DIFF
--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -8,14 +8,14 @@
 @include oColorsSetUseCase(o-buttons-standard-normal,   text,       'teal-1');
 @include oColorsSetUseCase(o-buttons-standard-normal,   background, 'white');
 @include oColorsSetUseCase(o-buttons-standard-normal,   border,     'teal-1');
-@include oColorsSetUseCase(o-buttons-standard-hover,    background, 'teal-1');
+@include oColorsSetUseCase(o-buttons-standard-hover,    background, 'teal-2');
 @include oColorsSetUseCase(o-buttons-standard-hover,    border,     'teal-1');
 @include oColorsSetUseCase(o-buttons-standard-active,   background, 'warm-2');
 @include oColorsSetUseCase(o-buttons-standard-active,   text,       'cold-3');
 @include oColorsSetUseCase(o-buttons-standard-active,   border,     'warm-2');
-@include oColorsSetUseCase(o-buttons-standard-pressedselected, background, 'teal-1');
-@include oColorsSetUseCase(o-buttons-standard-pressedselected, border,     'teal-1');
-
+@include oColorsSetUseCase(o-buttons-standard-pressedselected, background, 'teal-2');
+@include oColorsSetUseCase(o-buttons-standard-pressedselected, border,     'teal-2');
+@include oColorsSetUseCase(o-buttons-standard-pressedselected, text,       'teal-1');
 /// Theme: Standard
 ///
 /// @type Map
@@ -33,12 +33,12 @@ $o-buttons-themes__standard: (
 		border-color: oColorsGetColorFor(o-buttons-standard-active, border),
 	),
 	hover: (
-		background-color: rgba(oColorsGetColorFor(o-buttons-standard-hover, background), 0.08),
-		border-color: rgba(oColorsGetColorFor(o-buttons-standard-hover, border), 0.3),
+		background-color: rgba(oColorsGetColorFor(o-buttons-standard-hover, background), 0.1),
+		border-color: rgba(oColorsGetColorFor(o-buttons-standard-hover, border), 0.5),
 	),
 	pressedselected: (
-		background-color: rgba(oColorsGetColorFor(o-buttons-standard-pressedselected, background), 0.2) !important,
-		border-color: rgba(oColorsGetColorFor(o-buttons-standard-pressedselected, border), 0.2),
+		background-color: rgba(oColorsGetColorFor(o-buttons-standard-pressedselected, background), 0.4) !important,
+		border-color: rgba(oColorsGetColorFor(o-buttons-standard-pressedselected, border), 0.5),
 	)
 ) !default;
 
@@ -113,9 +113,12 @@ $o-buttons-themes__inverse: (
 	)
 ) !default;
 
-@include oColorsSetUseCase(o-buttons-uncolored-normal, text,       'pink-tint5');
+@include oColorsSetUseCase(o-buttons-uncolored-normal, text,       'cold-1');
 @include oColorsSetUseCase(o-buttons-uncolored-normal, background, 'transparent');
 @include oColorsSetUseCase(o-buttons-uncolored-normal, border,     'pink-tint5');
+@include oColorsSetUseCase(o-buttons-uncolored-hover, background, 'teal-2');
+@include oColorsSetUseCase(o-buttons-uncolored-hover, border, 'teal-1');
+@include oColorsSetUseCase(o-buttons-uncolored-pressedselected, background, 'teal-2');
 
 /// Theme: Uncolored
 ///
@@ -125,5 +128,12 @@ $o-buttons-themes__uncolored: (
 		color: oColorsGetColorFor(o-buttons-uncolored-normal, text),
 		background-color: oColorsGetColorFor(o-buttons-uncolored-normal, background),
 		border-color: oColorsGetColorFor(o-buttons-uncolored-normal, border),
+	),
+	hover: (
+		background-color: rgba(oColorsGetColorFor(o-buttons-uncolored-hover, background), 0.1),
+		border-color: rgba(oColorsGetColorFor(o-buttons-uncolored-hover, border), 0.5),
+	),
+	pressedselected: (
+		background-color: rgba(oColorsGetColorFor(o-buttons-uncolored-pressedselected, background), 0.2),
 	)
 ) !default;

--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -14,7 +14,7 @@
 @include oColorsSetUseCase(o-buttons-standard-active,   text,       'cold-3');
 @include oColorsSetUseCase(o-buttons-standard-active,   border,     'warm-2');
 @include oColorsSetUseCase(o-buttons-standard-pressedselected, background, 'teal-2');
-@include oColorsSetUseCase(o-buttons-standard-pressedselected, border,     'teal-2');
+@include oColorsSetUseCase(o-buttons-standard-pressedselected, border,     'teal-1');
 @include oColorsSetUseCase(o-buttons-standard-pressedselected, text,       'teal-1');
 /// Theme: Standard
 ///
@@ -63,7 +63,7 @@ $o-buttons-themes__standout: (
 	),
 	hover: (
 		color: oColorsGetColorFor(o-buttons-standout-normal, text),
-		background-color: lighten(oColorsGetColorFor(o-buttons-standout-normal, background), 3.7%),
+		background-color: lighten(oColorsGetColorFor(o-buttons-standout-normal, background), 0.8),
 		border-color: oColorsGetColorFor(o-buttons-standout-hover, border),
 	),
 	pressedselected: (


### PR DESCRIPTION
https://app.frontify.com/d/5GC1Squ8FMrZ/next-style-guide#/basics/buttons

![default after](https://cloud.githubusercontent.com/assets/3081639/18000566/a798393a-6b76-11e6-8db0-b4569eafc181.png)
![default before](https://cloud.githubusercontent.com/assets/3081639/18000571/a7be6434-6b76-11e6-96d6-6b6eb89ab8ba.png)
![group after](https://cloud.githubusercontent.com/assets/3081639/18000569/a7b2226e-6b76-11e6-8895-1002c02247b3.png)
![group before](https://cloud.githubusercontent.com/assets/3081639/18000567/a7b19d08-6b76-11e6-8d13-e75d72a6719e.png)
![uncolored after](https://cloud.githubusercontent.com/assets/3081639/18000568/a7b1ba40-6b76-11e6-8a0d-35c4a3168ca2.png)
![uncolored before](https://cloud.githubusercontent.com/assets/3081639/18000570/a7b2bd28-6b76-11e6-88e4-bec97e7d6373.png)
