### PR TITLE
Increase border opacity on standard button

### DIFF
--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -28,7 +28,7 @@ $o-buttons-themes__standard: (
 	normal: (
 		color: oColorsGetColorFor(o-buttons-standard-normal, text),
 		background-color: oColorsGetColorFor(o-buttons-standard-normal, background),
-		border-color: rgba(oColorsGetColorFor(o-buttons-standard-normal, border), 0.15),
+		border-color: rgba(oColorsGetColorFor(o-buttons-standard-normal, border), 0.4),
 	),
 	active: (
 		color: darken(oColorsGetColorFor(o-buttons-standard-active, text), 13%),


### PR DESCRIPTION
I missed this in the original design update.