### PR TITLE
Version 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The button CSS will work on `<button>` or `<a>` elements. It is important for ac
 
 ### Sass
 
-Mixins and [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles) are only available if you're including o-buttons in your project using bower or [OBT](https://github.com/Financial-Times/origami-build-tools). If you're using o-buttons via the [Build Service](https://www.ft.com/__origami/service/build/v2/), you must use the o-buttons classes instead. Both are documented below.
+Mixins and [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles) are only available if you're including o-buttons in your project using bower. If you're using o-buttons via the [Build Service](https://www.ft.com/__origami/service/build/v2/), you must use the o-buttons classes instead. Both are documented below.
 
 #### Default button
 
@@ -132,7 +132,7 @@ Or, using Sass:
 #### Size modifiers
 
 ```html
-<button class="o-buttons o-buttons">Default button</button>
+<button class="o-buttons">Default button</button>
 <button class="o-buttons o-buttons--big">Big button</button>
 ```
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,21 @@ Or, using Sass:
 
 ## Migration Guide
 
+### Migrating from v4 to v5
 
+This major includes the new o-colors and updates the themes and sizes of buttons.
 
+**Sizes** have been updated to `default` (`28px` min-height), and `big` (`40px` min-height) to correspond to the new baseline sizing introduced in the new o-typography. `Small` button size has been removed.
+
+The following changes have been made to the **themes**:
+
+- `Standard` is now `Secondary` and the default button style: use `o-buttons` or `o-buttons--secondary` classes
+- `Standout` is now `Primary`: use `o-buttons--primary` class
+- `Uncolored` is now `Mono`: use `o-buttons--mono` class
+
+Inverse and B2C themes have remained the same.
+
+Removes deprecated classnames: `o-buttons__pagination` and `o-buttons__group`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ o-buttons provides Sass mixins and variables to create buttons.
 - [Usage](#usage)
 	- [Markup](#markup)
 	- [Sass](#sass)
+- [Troubleshooting](#troubleshooting)
 - [Migration Guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
@@ -241,6 +242,12 @@ Or, using Sass:
 </button>
 ```
 
+
+## Troubleshooting
+
+In the past we've seen issues where adding styles to the `background` property of buttons with a low specificity selector can overwrite the `background-color` styles added by o-buttons, [see issue #76](https://github.com/Financial-Times/o-buttons/issues/76). This happens because o-buttons styles the `background-color` property on buttons to add color instead of the shorthand property, which allows for icons to be added to buttons using the remaining background properties.
+
+To avoid this, use the `background-color` property instead of the shorthand `background` property if you wish to overwrite a buttons background-color.
 
 ## Migration Guide
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,15 @@ The following changes have been made to the **themes**:
 
 Inverse and B2C themes have remained the same.
 
-Removes deprecated classnames: `o-buttons__pagination` and `o-buttons__group`.
+Removes deprecated classnames:
+
+```diff
+-.o-buttons__pagination
++.o-buttons-pagination
+
+-.o-buttons__group
++.o-buttons-group
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ o-buttons provides Sass mixins and variables to create buttons.
 - [Usage](#usage)
 	- [Markup](#markup)
 	- [Sass](#sass)
+- [Migration Guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
 
@@ -14,8 +15,8 @@ o-buttons provides Sass mixins and variables to create buttons.
 
 o-buttons provides styling for:
 
-- **Themes**: `o-buttons--{standard|standout|inverse|uncolored|b2c}` or `@include oButtonsTheme($theme)``
-- **Sizes**: `o-buttons--{small|medium|big}` or `@include oButtonsSize($size);`
+- **Themes**: `o-buttons--{primary|secondary|inverse|mono|b2c}` or `@include oButtonsTheme($theme)``
+- **Sizes**: `o-buttons--{default|big}` or `@include oButtonsSize($size);`
 - **Grouped buttons**: `o-buttons-group` or `@include oButtonsGroup;`
 - **Pagination buttons**: `o-buttons-pagination` or `@include oButtonsPagination;`
 - **Icon buttons**: `o-buttons-icon o-buttons-icon--{arrow-left| arrow-right}` or `@include oButtonsGetButtonForIconAndTheme($icon-name, $theme);`
@@ -34,14 +35,14 @@ The button CSS will work on `<button>` or `<a>` elements. It is important for ac
 
 ### Sass
 
-> Mixins and [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles) are only available if you're including o-buttons in your project using bower or OBT. If you're using o-buttons via the Build Service, you must use the o-buttons classes instead. Both are documented below.
+Mixins and [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles) are only available if you're including o-buttons in your project using bower or [OBT](https://github.com/Financial-Times/origami-build-tools). If you're using o-buttons via the [Build Service](https://www.ft.com/__origami/service/build/v2/), you must use the o-buttons classes instead. Both are documented below.
 
 #### Default button
 
 [View demos](http://registry.origami.ft.com/components/o-buttons)
 
 ```html
-<button class="o-buttons">Standard</button>
+<button class="o-buttons">Primary</button>
 ```
 
 Or, using Sass:
@@ -53,14 +54,14 @@ Or, using Sass:
 ```
 
 ```html
-<button class="my-button-class">Standard</button>
+<button class="my-button-class">Primary</button>
 ```
 
 
 #### States
 
 ```html
-<button class="o-buttons">Standard</button>
+<button class="o-buttons">Primary</button>
 <button class="o-buttons" aria-selected="true">Selected</button>
 <button class="o-buttons" aria-pressed="true">Pressed</button>
 <button class="o-buttons" disabled>Disabled</button>
@@ -130,7 +131,7 @@ Or, using Sass:
 #### Size modifiers
 
 ```html
-<button class="o-buttons o-buttons--medium">Medium button (default)</button>
+<button class="o-buttons o-buttons">Default button</button>
 <button class="o-buttons o-buttons--big">Big button</button>
 ```
 
@@ -160,8 +161,8 @@ Or, using Sass:
 [View demos](http://registry.origami.ft.com/components/o-buttons)
 
 ```html
-<button class="o-buttons o-buttons--standout">Standout button</button>
-<button class="o-buttons o-buttons--uncolored">Uncolored button</button>
+<button class="o-buttons o-buttons--secondary">Secondary button</button>
+<button class="o-buttons o-buttons--mono">Mono button</button>
 <button class="o-buttons o-buttons--inverse">Inverse button</button>
 <button class="o-buttons o-buttons--b2c">B2C button</button>
 
@@ -173,20 +174,20 @@ Or, using Sass:
 .my-button-class {
 	@include oButtons();
 }
-.my-button-class--standout {
-	@include oButtonsTheme(standout);
+.my-button-class--secondary {
+	@include oButtonsTheme(secondary);
 }
 
 // Or…
-.my-standout-button {
-	@include oButtons($theme: standout);
+.my-secondary-button {
+	@include oButtons($theme: secondary);
 }
 ```
 
 ```html
-<button class="my-button-class my-button-class--standout">Standout button</button>
+<button class="my-button-class my-button-class--secondary">Secondary button</button>
 
-<button class="my-standout-button">Standout button</button>
+<button class="my-secondary-button">Secondary button</button>
 ```
 
 #### Icons
@@ -220,7 +221,7 @@ Or, using Sass:
 
 .my-button-class--icon-star {
 	// icon here can be *any* icon tag (eg arrow-left) in fticons
-	@include oButtonsGetButtonForIconAndTheme(star, standout);
+	@include oButtonsGetButtonForIconAndTheme(star, secondary);
 }
 
 .my-button-class-icon__label {
@@ -239,6 +240,12 @@ Or, using Sass:
 	<span class="my-button-class-icon__label">star</span>
 </button>
 ```
+
+
+## Migration Guide
+
+
+
 
 ---
 

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "main.scss"
   ],
   "dependencies": {
-    "o-colors": "^3.5.2",
+    "o-colors": "^4.0.1",
     "o-hoverable": ">=0.1.1 <4",
     "o-icons": ">=4.4.2 <6",
     "o-normalise": "^1.2.0"

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
   ],
   "dependencies": {
     "o-colors": "^4.0.1",
-    "o-hoverable": ">=0.1.1 <4",
     "o-icons": ">=4.4.2 <6",
     "o-normalise": "^1.2.0"
   }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,25 +2,6 @@ $o-buttons-is-silent: false;
 
 @import "../../main";
 
-
-@mixin _oButtonsStatesAsClasses($theme) {
-	&.hover {
-		@include _oButtonsPropertiesForState($theme, hover);
-	}
-	&.active {
-		@include _oButtonsPropertiesForState($theme, active);
-	}
-	&.focus {
-		@include _oButtonsPropertiesForState($theme, focus);
-	}
-}
-
-@each $theme, $properties in $o-buttons-themes {
-	.#{$o-buttons-class}--#{$theme} {
-		@include _oButtonsStatesAsClasses($theme);
-	}
-}
-
 html {
 	@include oColorsFor(page);
 }
@@ -39,21 +20,5 @@ body {
 }
 
 .inverse {
-	background: oColorsGetPaletteColor('grey-tint5');
-}
-
-// Set the backgrounds for hover states as actual hex values using mix()
-// because Pa11y isn't liking the transparent backgrounds that are set in our colours
-//
-.o-buttons.o-buttons--uncolored.hover {
-	background: mix(oColorsGetColorFor(o-buttons-uncolored-hover, background), #fff1e0, 10);
-}
-
-.o-buttons.o-buttons--standard.hover {
-	background: mix(oColorsGetColorFor(o-buttons-standard-hover, background), #fff1e0, 8);
-}
-
-.o-buttons.o-buttons--b2c.hover {
-	// background: darken(oColorsGetColorFor(o-buttons-b2c-hover, background), 14);
-	background: mix(oColorsGetColorFor(o-buttons-b2c-hover, background), #fff1e0, 80);
+	background-color: oColorsGetPaletteColor('slate');
 }

--- a/demos/src/inverse.mustache
+++ b/demos/src/inverse.mustache
@@ -1,3 +1,3 @@
-<button class="o-buttons o-buttons--small o-buttons--inverse">Inverse</button>
 <button class="o-buttons o-buttons--inverse">Inverse</button>
 <button class="o-buttons o-buttons--inverse o-buttons--big">Inverse</button>
+<button class="o-buttons o-buttons--inverse o-buttons--big" disabled>Inverse</button>

--- a/demos/src/mono.mustache
+++ b/demos/src/mono.mustache
@@ -1,0 +1,3 @@
+<button class="o-buttons o-buttons--mono">Mono</button>
+<button class="o-buttons o-buttons--mono o-buttons--big">Mono</button>
+<button class="o-buttons o-buttons--mono o-buttons--big" disabled>Mono</button>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -2,16 +2,16 @@
 
 <h3>With anchors</h3>
 <a href="#void" role="button" class="o-buttons">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standard hover">Hover</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standard active">Active</a>
+<a href="#void" role="button" class="o-buttons o-buttons--primary hover">Hover</a>
+<a href="#void" role="button" class="o-buttons o-buttons--primary active">Active</a>
 <a href="#void" role="button" class="o-buttons" aria-pressed="true">Pressed</a>
 
 <br />
 <br />
 
 <a href="#void" role="button" class="o-buttons o-buttons--big">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--big o-buttons--standard hover">Hover</a>
-<a href="#void" role="button" class="o-buttons o-buttons--big o-buttons--standard active">Active</a>
+<a href="#void" role="button" class="o-buttons o-buttons--big o-buttons--primary hover">Hover</a>
+<a href="#void" role="button" class="o-buttons o-buttons--big o-buttons--primary active">Active</a>
 <a href="#void" role="button" class="o-buttons o-buttons--big" aria-pressed="true">Pressed</a>
 
 <br />
@@ -19,44 +19,46 @@
 
 <h3>With input[type=submit]</h3>
 <input type="submit" class="o-buttons" value="Standard" />
-<input type="submit" class="o-buttons o-buttons--standard hover" value="Hover" />
-<input type="submit" class="o-buttons o-buttons--standard active" value="Active" />
+<input type="submit" class="o-buttons o-buttons--primary hover" value="Hover" />
+<input type="submit" class="o-buttons o-buttons--primary active" value="Active" />
 <input type="submit" class="o-buttons" aria-pressed="true" value="Pressed" />
 
 <br />
 <br />
 
 <input type="submit" class="o-buttons o-buttons--big" value="Standard" />
-<input type="submit" class="o-buttons o-buttons--big o-buttons--standard hover" value="Hover" />
-<input type="submit" class="o-buttons o-buttons--big o-buttons--standard active" value="Active" />
+<input type="submit" class="o-buttons o-buttons--big o-buttons--primary hover" value="Hover" />
+<input type="submit" class="o-buttons o-buttons--big o-buttons--primary active" value="Active" />
 <input type="submit" class="o-buttons o-buttons--big" aria-pressed="true" value="Pressed" />
+<input type="submit" class="o-buttons o-buttons--big o-buttons--primary" disabled value="Disabled" />
 
 <h3>With input[type=button]</h3>
 <input type="button" class="o-buttons" value="Standard" />
-<input type="button" class="o-buttons o-buttons--standard hover" value="Hover" />
-<input type="button" class="o-buttons o-buttons--standard active" value="Active" />
+<input type="button" class="o-buttons o-buttons--primary hover" value="Hover" />
+<input type="button" class="o-buttons o-buttons--primary active" value="Active" />
 <input type="button" class="o-buttons" aria-pressed="true" value="Pressed" />
+<input type="button" class="o-buttons o-buttons--primary" disabled value="Disabled" />
 
 <br />
 <br />
 
 <input type="button" class="o-buttons o-buttons--big" value="Standard" />
-<input type="button" class="o-buttons o-buttons--big o-buttons--standard hover" value="Hover" />
-<input type="button" class="o-buttons o-buttons--big o-buttons--standard active" value="Active" />
+<input type="button" class="o-buttons o-buttons--big o-buttons--primary hover" value="Hover" />
+<input type="button" class="o-buttons o-buttons--big o-buttons--primary active" value="Active" />
 <input type="button" class="o-buttons o-buttons--big" aria-pressed="true" value="Pressed" />
 
 <h3>With buttons</h3>
 <button class="o-buttons">Standard</button>
-<button class="o-buttons o-buttons--standard hover">Hover</button>
-<button class="o-buttons o-buttons--standard active">Active</button>
+<button class="o-buttons o-buttons--primary hover">Hover</button>
+<button class="o-buttons o-buttons--primary active">Active</button>
 <button class="o-buttons" aria-pressed="true">Pressed</button>
 
 <br />
 <br />
 
 <button class="o-buttons o-buttons--big">Standard</button>
-<button class="o-buttons o-buttons--big o-buttons--standard hover">Hover</button>
-<button class="o-buttons o-buttons--big o-buttons--standard active">Active</button>
+<button class="o-buttons o-buttons--big o-buttons--primary hover">Hover</button>
+<button class="o-buttons o-buttons--big o-buttons--primary active">Active</button>
 <button class="o-buttons o-buttons--big" aria-pressed="true">Pressed</button>
 
 <br />
@@ -110,65 +112,65 @@
 <h2>Standout</h2>
 
 <h3>With anchors</h3>
-<a href="#void" role="button" class="o-buttons o-buttons--standout">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standout hover">Hover</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standout hover active">Active</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standout" aria-pressed="true">Pressed</a>
+<a href="#void" role="button" class="o-buttons o-buttons--secondary">Standard</a>
+<a href="#void" role="button" class="o-buttons o-buttons--secondary hover">Hover</a>
+<a href="#void" role="button" class="o-buttons o-buttons--secondary hover active">Active</a>
+<a href="#void" role="button" class="o-buttons o-buttons--secondary" aria-pressed="true">Pressed</a>
 
 <br />
 <br />
 
-<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big hover">Hover</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big hover active">Active</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" aria-pressed="true">Pressed</a>
+<a href="#void" role="button" class="o-buttons o-buttons--secondary o-buttons--big">Standard</a>
+<a href="#void" role="button" class="o-buttons o-buttons--secondary o-buttons--big hover">Hover</a>
+<a href="#void" role="button" class="o-buttons o-buttons--secondary o-buttons--big hover active">Active</a>
+<a href="#void" role="button" class="o-buttons o-buttons--secondary o-buttons--big" aria-pressed="true">Pressed</a>
 
 
 <h3>With buttons</h3>
 
-<button class="o-buttons o-buttons--standout">Standard</button>
-<button class="o-buttons o-buttons--standout hover">Hover</button>
-<button class="o-buttons o-buttons--standout active">Active</button>
-<button class="o-buttons o-buttons--standout" aria-pressed="true">Pressed</button>
+<button class="o-buttons o-buttons--secondary">Standard</button>
+<button class="o-buttons o-buttons--secondary hover">Hover</button>
+<button class="o-buttons o-buttons--secondary active">Active</button>
+<button class="o-buttons o-buttons--secondary" aria-pressed="true">Pressed</button>
 
 <br />
 <br />
 
-<button class="o-buttons o-buttons--standout o-buttons--big">Standard</button>
-<button class="o-buttons o-buttons--standout o-buttons--big hover">Hover</button>
-<button class="o-buttons o-buttons--standout o-buttons--big active">Active</button>
-<button class="o-buttons o-buttons--standout o-buttons--big" aria-pressed="true">Pressed</button>
+<button class="o-buttons o-buttons--secondary o-buttons--big">Standard</button>
+<button class="o-buttons o-buttons--secondary o-buttons--big hover">Hover</button>
+<button class="o-buttons o-buttons--secondary o-buttons--big active">Active</button>
+<button class="o-buttons o-buttons--secondary o-buttons--big" aria-pressed="true">Pressed</button>
 
 
 <h2>Uncolored</h2>
 
 <h3>With anchors</h3>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored hover">Hover</a>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored active">Active</a>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored" aria-pressed="true">Pressed</a>
+<a href="#void" role="button" class="o-buttons o-buttons--mono">Standard</a>
+<a href="#void" role="button" class="o-buttons o-buttons--mono hover">Hover</a>
+<a href="#void" role="button" class="o-buttons o-buttons--mono active">Active</a>
+<a href="#void" role="button" class="o-buttons o-buttons--mono" aria-pressed="true">Pressed</a>
 
 <br />
 <br />
 
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big hover">Hover</a>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big active">Active</a>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" aria-pressed="true">Pressed</a>
+<a href="#void" role="button" class="o-buttons o-buttons--mono o-buttons--big">Standard</a>
+<a href="#void" role="button" class="o-buttons o-buttons--mono o-buttons--big hover">Hover</a>
+<a href="#void" role="button" class="o-buttons o-buttons--mono o-buttons--big active">Active</a>
+<a href="#void" role="button" class="o-buttons o-buttons--mono o-buttons--big" aria-pressed="true">Pressed</a>
 
 <h3>With buttons</h3>
-<button class="o-buttons o-buttons--uncolored">Standard</button>
-<button class="o-buttons o-buttons--uncolored hover">Hover</button>
-<button class="o-buttons o-buttons--uncolored active">Active</button>
-<button class="o-buttons o-buttons--uncolored" aria-pressed="true">Pressed</button>
+<button class="o-buttons o-buttons--mono">Standard</button>
+<button class="o-buttons o-buttons--mono hover">Hover</button>
+<button class="o-buttons o-buttons--mono active">Active</button>
+<button class="o-buttons o-buttons--mono" aria-pressed="true">Pressed</button>
 
 <br />
 <br />
 
-<button class="o-buttons o-buttons--uncolored o-buttons--big">Standard</button>
-<button class="o-buttons o-buttons--uncolored o-buttons--big hover">Hover</button>
-<button class="o-buttons o-buttons--uncolored o-buttons--big active">Active</button>
-<button class="o-buttons o-buttons--uncolored o-buttons--big" aria-pressed="true">Pressed</button>
+<button class="o-buttons o-buttons--mono o-buttons--big">Standard</button>
+<button class="o-buttons o-buttons--mono o-buttons--big hover">Hover</button>
+<button class="o-buttons o-buttons--mono o-buttons--big active">Active</button>
+<button class="o-buttons o-buttons--mono o-buttons--big" aria-pressed="true">Pressed</button>
 
 <h2>Inverse</h2>
 

--- a/demos/src/primary.mustache
+++ b/demos/src/primary.mustache
@@ -1,0 +1,3 @@
+<button class="o-buttons">Primary</button>
+<button class="o-buttons o-buttons--big">Primary</button>
+<button class="o-buttons o-buttons--big" disabled>Primary</button>

--- a/demos/src/primary.mustache
+++ b/demos/src/primary.mustache
@@ -1,3 +1,4 @@
-<button class="o-buttons">Primary</button>
-<button class="o-buttons o-buttons--big">Primary</button>
-<button class="o-buttons o-buttons--big" disabled>Primary</button>
+<button class="o-buttons o-buttons--primary">Primary</button>
+<button class="o-buttons o-buttons--primary o-buttons--big">Primary</button>
+<button class="o-buttons o-buttons--primary o-buttons--big" disabled>Primary</button>
+

--- a/demos/src/secondary.mustache
+++ b/demos/src/secondary.mustache
@@ -1,0 +1,3 @@
+<button class="o-buttons o-buttons--secondary">Secondary</button>
+<button class="o-buttons o-buttons--secondary o-buttons--big">Secondary</button>
+<button class="o-buttons o-buttons--secondary o-buttons--big" disabled>Secondary</button>

--- a/demos/src/secondary.mustache
+++ b/demos/src/secondary.mustache
@@ -1,3 +1,3 @@
-<button class="o-buttons o-buttons--secondary">Secondary</button>
-<button class="o-buttons o-buttons--secondary o-buttons--big">Secondary</button>
-<button class="o-buttons o-buttons--secondary o-buttons--big" disabled>Secondary</button>
+<button class="o-buttons">Secondary</button>
+<button class="o-buttons o-buttons--big">Secondary</button>
+<button class="o-buttons o-buttons--big" disabled>Secondary</button>

--- a/demos/src/standard.mustache
+++ b/demos/src/standard.mustache
@@ -1,3 +1,0 @@
-<button class="o-buttons o-buttons--small">Standard</button>
-<button class="o-buttons">Standard</button>
-<button class="o-buttons o-buttons--big">Standard</button>

--- a/demos/src/standout.mustache
+++ b/demos/src/standout.mustache
@@ -1,3 +1,0 @@
-<button class="o-buttons o-buttons--standout o-buttons--small">Standout</button>
-<button class="o-buttons o-buttons--standout">Standout</button>
-<button class="o-buttons o-buttons--standout o-buttons--big">Standout</button>

--- a/demos/src/uncolored.mustache
+++ b/demos/src/uncolored.mustache
@@ -1,3 +1,0 @@
-<button class="o-buttons o-buttons--small o-buttons--uncolored">Uncolored</button>
-<button class="o-buttons o-buttons--uncolored">Uncolored</button>
-<button class="o-buttons o-buttons--uncolored o-buttons--big">Uncolored</button>

--- a/designguidelines.md
+++ b/designguidelines.md
@@ -1,8 +1,8 @@
 #### Themes
 
-* __default__: teal outline
-* __standout__: solid teal
-* __uncolored__: monochrome
+* __default__/__secondary__: teal outline
+* __primary__: solid teal
+* __mono__: monochrome
 * __inverse__: for use on dark backgrounds
 * __b2c__: A theme for b2c products eg [http://help.ft.com](http://help.ft.com)
 
@@ -10,9 +10,8 @@ and the following sizes:
 
 #### Sizes
 
-* __small__: 22px high
-* __default__: 26px high
-* __big__: 36px high
+* __default__: 28px high
+* __big__: 40px high
 
 and have the following states:
 

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,5 @@
 @import 'o-normalise/main';
 @import 'o-colors/main';
-@import 'o-hoverable/main';
 @import 'o-icons/main';
 
 // Switch off component deprecation warnings

--- a/main.scss
+++ b/main.scss
@@ -24,21 +24,19 @@ $_o-buttons-deprecation-warnings: false;
 			@include oButtonsSize($size);
 		}
 	}
+
 	@each $theme, $properties in $o-buttons-themes {
 		.#{$o-buttons-class}--#{$theme} {
 			@include oButtonsTheme($theme);
 		}
 	}
-	.#{$o-buttons-class}__pagination, // Deprecated, invalidates the BEM naming convention
+
 	.#{$o-buttons-class}-pagination {
 		@include oButtonsPagination;
 	}
 
-
 	@include oButtonsIcon;
 
-
-	.#{$o-buttons-class}__group, // Deprecated, invalidates the BEM naming convention
 	.#{$o-buttons-class}-group {
 		@include oButtonsGroup;
 	}

--- a/main.scss
+++ b/main.scss
@@ -2,9 +2,6 @@
 @import 'o-colors/main';
 @import 'o-icons/main';
 
-// Switch off component deprecation warnings
-$_o-buttons-deprecation-warnings: false;
-
 @import 'scss/themes';
 @import 'scss/variables';
 @import 'scss/functions';
@@ -44,6 +41,3 @@ $_o-buttons-deprecation-warnings: false;
 	// Set module to silent again
 	$o-buttons-is-silent: true !global;
 }
-
-// Switch deprecation warnings back on
-$_o-buttons-deprecation-warnings: true;

--- a/origami.json
+++ b/origami.json
@@ -13,7 +13,7 @@
     "sass": "demos/src/demo.scss",
     "js": "demos/src/demo.js",
     "dependencies": [
-      "o-fonts@^1.4.0"
+      "o-fonts@^3.0.0"
     ]
   },
   "demos": [

--- a/origami.json
+++ b/origami.json
@@ -18,16 +18,16 @@
   },
   "demos": [
     {
-      "name": "standard",
-      "title": "Masterbrand standard theme",
-      "template": "/demos/src/standard.mustache",
-      "description": "Standard theme for masterbrand buttons. This is the default theme."
+      "name": "primary",
+      "title": "Masterbrand primary buttons",
+      "template": "/demos/src/primary.mustache",
+      "description": "Primary theme for masterbrand buttons. This is the default theme."
     },
     {
-      "name": "standout",
-      "title": "Masterbrand standout theme",
-      "template": "/demos/src/standout.mustache",
-      "description": "Standout buttons should be used for primary actions."
+      "name": "secondary",
+      "title": "Masterbrand secondary buttons",
+      "template": "/demos/src/secondary.mustache",
+      "description": "Secondary buttons should be used for primary actions."
     },
     {
       "name": "inverse",
@@ -35,6 +35,12 @@
       "template": "/demos/src/inverse.mustache",
       "bodyClasses": "inverse",
       "description": "Inverse buttons for use on dark backgrounds."
+    },
+    {
+      "name": "mono",
+      "title": "Monochrome buttons",
+      "template": "/demos/src/mono.mustache",
+      "description": "A monochrome theme for people who need a different theme to those supported by o-buttons (Masterbrand and b2c)"
     },
     {
       "name": "B2C",
@@ -65,12 +71,6 @@
       "template": "/demos/src/pa11y.mustache",
       "hidden": true,
       "description": "Pa11y test for accesibility"
-    },
-    {
-      "name": "uncolored",
-      "template": "/demos/src/uncolored.mustache",
-      "hidden": true,
-      "description": "An uncolored theme for people who need a different theme to those supported by o-buttons (Masterbrand and b2c)"
     }
   ]
 }

--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -4,7 +4,11 @@
 /// @param {String} $state - One of normal, hover, focus, selected, disabled, pressed
 @function _oButtonsThemeHasState($theme, $state) {
 	$states: map-get($o-buttons-themes, $theme);
-	@return map-has-key($states, $state);
+	@if type-of($states) == map {
+		@return map-has-key($states, $state);
+	} @else {
+		@return false;
+	}
 }
 
 /// Check if a state has a property
@@ -18,7 +22,13 @@
 @function _oButtonsStateHasProperty($theme, $state, $property) {
 	$states: map-get($o-buttons-themes, $theme);
 	$properties: map-get($states, $state);
-	@return map-has-key($properties, $property);
+
+	@if type-of($properties) == map {
+		@return map-has-key($properties, $property);
+	} @else {
+		@return false;
+	}
+
 }
 
 /// Get the value of a property in a given state
@@ -34,5 +44,9 @@
 @function _oButtonsStateGetProperty($theme, $state, $property) {
 	$states: map-get($o-buttons-themes, $theme);
 	$properties: map-get($states, $state);
-	@return map-get($properties, $property);
+	@if type-of($properties) == map {
+		@return map-get($properties, $property);
+	} @else {
+		@return false;
+	}
 }

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -1,19 +1,19 @@
 /// Icon Buttons
 ///
 /// Outputs styles for every icon in o-buttons-icons at every theme in o-buttons-themes
-
+/// @param {String} $buttonClass - class to apply o-buttons styles to
 @mixin oButtonsIcon($buttonClass: $o-buttons-class) {
-  // Browserhack to only apply these styles for IE7 and up. IE6 will get the
-  // text fallback. Hack documented here: http://browserhacks.com/#hack-da690292d4fddd94dc7bdd50e38b5713
-  html > body .#{$buttonClass}-icon {
-    @include oButtonsBaseStyles;
+	// Browserhack to only apply these styles for IE7 and up. IE6 will get the
+	// text fallback. Hack documented here: http://browserhacks.com/#hack-da690292d4fddd94dc7bdd50e38b5713
+	html > body .#{$buttonClass}-icon {
+		@include oButtonsBaseStyles;
 
-    @each $theme, $properties in $o-buttons-themes {
-      @each $icon in $o-buttons-icons {
-        @include oButtonsGetButtonForIconAndTheme($icon, $theme);
-      }
-    }
-  }
+		@each $theme, $properties in $o-buttons-themes {
+			@each $icon in $o-buttons-icons {
+				@include oButtonsGetButtonForIconAndTheme($icon, $theme);
+			}
+		}
+	}
 }
 
 /// Get Button For Icon and Theme
@@ -22,78 +22,88 @@
 /// in that theme's state list
 /// example:
 /// .my-button--left-arrow {
-///   @include oButtonsGetButtonForIconAndTheme(left-arrow, standout);
+///	 @include oButtonsGetButtonForIconAndTheme(left-arrow, standout);
 /// }
 ///
 /// @param {String} $icon-name, any icon name found in o-ft-icons
 /// @param {String} $theme, any theme name as defined in $o-buttons-themes (standard, standout, etc). Defaults to standard.
 /// @param {String} $button-class, defaults to o-buttons ($o-buttons-class' default value)
 ///
+@mixin oButtonsGetButtonForIconAndTheme($icon-name, $theme: primary, $buttonClass: $o-buttons-class) {
 
-@mixin oButtonsGetButtonForIconAndTheme($icon-name, $theme: standard, $buttonClass: $o-buttons-class) {
+	&.#{$buttonClass}-icon--#{$icon-name} {
 
-  &.#{$buttonClass}-icon--#{$icon-name} {
+		$theme-selector: null;
+		@if $theme == 'primary' {
+			$theme-selector: '&';
+		} @else {
+			$theme-selector: '&.#{$buttonClass}--#{$theme}';
+		}
 
-    $theme-selector: null;
-    @if $theme == 'standard' {
-      $theme-selector: '&';
-    } @else {
-      $theme-selector: '&.#{$buttonClass}--#{$theme}';
-    }
+		#{$theme-selector} {
+			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, normal);
 
-    #{$theme-selector} {
-      $state-list: map-get($o-buttons-themes, $theme); // normal, active, hover, focus, pressedselected, disabled
+			// http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
+			// http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
+			&[aria-selected=true], // e.g. A selected tab or page number in pagination
+			&[aria-pressed=true] { // e.g. A "follow" button that is pressed
+				@include _oButtonsGetIconForThemeAndState($icon-name, $theme, pressedselected);
+			}
 
-      @include _oButtonsGetIconForThemeAndState($icon-name, $state-list, normal);
+			&[disabled] {
+				@include _oButtonsGetIconForThemeAndState($icon-name, $theme, normal);
+			}
 
-      // http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
-      // http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
-      &[aria-selected=true], // e.g. A selected tab or page number in pagination
-      &[aria-pressed=true] { // e.g. A "follow" button that is pressed
-        @include _oButtonsGetIconForThemeAndState($icon-name, $state-list, pressedselected);
-      }
+			&:not([disabled]) {
+				&:focus:not(:hover),
+				&:hover {
+					@include _oButtonsGetIconForThemeAndState($icon-name, $theme, hover);
+				}
+				&:active {
+					@include _oButtonsGetIconForThemeAndState($icon-name, $theme, active);
+				}
+			}
 
-      &[disabled] {
-        @include _oButtonsGetIconForThemeAndState($icon-name, $state-list, disabled);
-      }
-
-      &:not([disabled]):active {
-        @include _oButtonsGetIconForThemeAndState($icon-name, $state-list, active);
-      }
-
-      // Hack to get the active state colour svg to download to prevent FOIC
-      &:after {
-        @include _oButtonsGetIconForThemeAndState($icon-name, $state-list, active);
-        content: '';
-      }
-    }
-  }
+			// Hack to get the active state colour svg to download to prevent FOIC
+			&:after {
+				@include _oButtonsGetIconForThemeAndState($icon-name, $theme, active);
+				content: '';
+			}
+		}
+	}
 }
 
+/// Base styling for buttons
+///
+/// @param {String} $button-class, defaults to o-buttons ($o-buttons-class' default value)
 @mixin oButtonsBaseStyles($buttonClass: $o-buttons-class) {
-  display: inline-block;
-  background-repeat: no-repeat;
-  background-position: 3px;
-  padding-left: 22px;
+	display: inline-block;
+	background-repeat: no-repeat;
+	background-position: 3px;
+	padding-left: 22px;
 
-  &.o-buttons-icon--icon-only {
-    padding-left: 0;
-    background-position: 50%;
-  }
+	&.o-buttons-icon--icon-only {
+		padding-left: 0;
+		background-position: 50%;
+	}
 
-  .#{$buttonClass}-icon__label {
-    @include oButtonsIconButtonLabel;
-  }
+	.#{$buttonClass}-icon__label {
+		@include oButtonsIconButtonLabel;
+	}
 }
 
-@mixin _oButtonsGetIconForThemeAndState($icon-name, $state-list, $state) {
-  @if map-has-key($state-list, $state) {
-    $properties: map-get($state-list, $state);
-    $icon-color: map-get($properties, color); // Icon color-should match the text color
-    @if $icon-color != null {
-      @include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: $icon-color, $iconset-version: 1);
-    }
-  }
+/// Request an icon from o-icons with color based on the o-buttons theme and state
+///
+/// @param {String} $icon-name, icon to request
+/// @param {String} $theme, one of $o-colors-theme
+/// @param {String} $state - One of normal, hover, focus, selected, disabled, pressed
+@mixin _oButtonsGetIconForThemeAndState($icon-name, $theme, $state) {
+	$state-color: 'o-buttons-#{$theme}-#{$state}';
+	$icon-color: oColorsGetColorFor($state-color, text);
+
+	@if $icon-color != null {
+		@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: $icon-color, $iconset-version: 1);
+	}
 }
 
 /// Icon Button Label
@@ -103,10 +113,9 @@
 /// label. This solution also works well for screen readers.
 /// This mixin outputs the styles for visually hiding the label
 ///
-///
 @mixin oButtonsIconButtonLabel() {
-  font-size: 0;
-  height: 1px;
-  overflow: hidden;
-  display: block;
+	font-size: 0;
+	height: 1px;
+	overflow: hidden;
+	display: block;
 }

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -29,12 +29,12 @@
 /// @param {String} $theme, any theme name as defined in $o-buttons-themes (standard, standout, etc). Defaults to standard.
 /// @param {String} $button-class, defaults to o-buttons ($o-buttons-class' default value)
 ///
-@mixin oButtonsGetButtonForIconAndTheme($icon-name, $theme: primary, $buttonClass: $o-buttons-class) {
+@mixin oButtonsGetButtonForIconAndTheme($icon-name, $theme: secondary, $buttonClass: $o-buttons-class) {
 
 	&.#{$buttonClass}-icon--#{$icon-name} {
 
 		$theme-selector: null;
-		@if $theme == 'primary' {
+		@if $theme == 'secondary' {
 			$theme-selector: '&';
 		} @else {
 			$theme-selector: '&.#{$buttonClass}--#{$theme}';

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -93,12 +93,12 @@
 ///  }
 /// @example Custom size and theme
 ///  .my-big-standout-button {
-///  	@include oButtons(big, standout);
+///  	@include oButtons(big, primary);
 ///  }
 ///
-/// @param {String} $size (medium)
-/// @param {String} $theme (standard)
-@mixin oButtons($size: default, $theme: primary) {
+/// @param {String} $size (default)
+/// @param {String} $theme (secondary)
+@mixin oButtons($size: default, $theme: secondary) {
 	display: inline-block;
 	box-sizing: border-box;
 	vertical-align: middle;

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -67,16 +67,12 @@
 	}
 
 	&:not([disabled]) {
-		&:focus:not(:hover),
-		#{$o-hoverable-if-hover-enabled} &:hover {
+		&:hover {
 			@include _oButtonsPropertiesForState($theme, hover);
 		}
 		&:active {
 			@include _oButtonsPropertiesForState($theme, active);
 		}
-	}
-	&:focus:not(:active):not(:hover) {
-		@include _oButtonsPropertiesForState($theme, focus);
 	}
 }
 
@@ -102,7 +98,7 @@
 ///
 /// @param {String} $size (medium)
 /// @param {String} $theme (standard)
-@mixin oButtons($size: medium, $theme: standard) {
+@mixin oButtons($size: default, $theme: primary) {
 	display: inline-block;
 	box-sizing: border-box;
 	vertical-align: middle;
@@ -138,6 +134,12 @@
 		pointer-events: none;
 		opacity: 0.4;
 		cursor: default;
+	}
+
+	&:focus {
+		outline-color: oColorsGetPaletteColor('teal-100');
+		outline-style: solid;
+		outline-width: 2px;
 	}
 
 	// Remove extra padding in Firefox

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -62,10 +62,6 @@
 		@include _oButtonsPropertiesForState($theme, pressedselected);
 	}
 
-	&[disabled] {
-		@include _oButtonsPropertiesForState($theme, disabled);
-	}
-
 	&:not([disabled]) {
 		&:hover {
 			@include _oButtonsPropertiesForState($theme, hover);

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -28,6 +28,7 @@
 
 // Properties for a state of a given theme
 //
+// @param {String} $theme - One of $o-buttons-themes
 // @param {String} $state - One of normal, hover, focus, selected, disabled, pressed
 @mixin _oButtonsPropertiesForState($theme, $state) {
 	@if _oButtonsThemeHasState($theme, $state) {
@@ -36,6 +37,9 @@
 		@each $property, $value in map-get($states, $state) {
 			#{$property}: #{$value};
 		}
+	} @else {
+		$colorsFor: 'o-buttons-#{$theme}-#{$state}';
+		@include oColorsFor($colorsFor);
 	}
 }
 

--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -3,170 +3,85 @@
 /// @link http://registry.origami.ft.com/components/o-buttons
 ////
 
+// Set custom color white over black @ 20%
+@include oColorsSetColor('white-black-20', oColorsMix($color: 'white', $background: 'black', $percentage: 20));
+
 /// scss-lint:disable SpaceAfterComma
 
-@include oColorsSetColor('o-buttons-teal-3', #17484C);
-@include oColorsSetColor('o-buttons-teal-4', #0A2F33);
+// Theme: primary
 
+@include oColorsSetUseCase(o-buttons-primary-normal,   text,              'white');
+@include oColorsSetUseCase(o-buttons-primary-normal,   border,            'teal-50');
+@include oColorsSetUseCase(o-buttons-primary-normal,   background,        'teal-50');
+@include oColorsSetUseCase(o-buttons-primary-hover,    text,              'white');
+@include oColorsSetUseCase(o-buttons-primary-hover,    border,            'teal-30');
+@include oColorsSetUseCase(o-buttons-primary-hover,    background,        'teal-30');
+@include oColorsSetUseCase(o-buttons-primary-active,   text,              'teal-30');
+@include oColorsSetUseCase(o-buttons-primary-active,   border,            'teal-80');
+@include oColorsSetUseCase(o-buttons-primary-active,   background,        'teal-80');
+@include oColorsSetUseCase(o-buttons-primary-pressedselected, text,       'teal-30');
+@include oColorsSetUseCase(o-buttons-primary-pressedselected, border,     'teal-80');
+@include oColorsSetUseCase(o-buttons-primary-pressedselected, background, 'teal-80');
 
-@include oColorsSetUseCase(o-buttons-standard-normal,   text,       'o-buttons-teal-3');
-@include oColorsSetUseCase(o-buttons-standard-normal,   border,     'teal-1');
-@include oColorsSetUseCase(o-buttons-standard-normal,   background,     'transparent');
-@include oColorsSetUseCase(o-buttons-standard-hover,    background, 'teal-2');
-@include oColorsSetUseCase(o-buttons-standard-hover,    border,     'teal-1');
-@include oColorsSetUseCase(o-buttons-standard-active,   background, 'warm-2');
-@include oColorsSetUseCase(o-buttons-standard-active,   text,       'teal-1');
-@include oColorsSetUseCase(o-buttons-standard-active,   border,     'warm-2');
-@include oColorsSetUseCase(o-buttons-standard-pressedselected, background, 'teal-2');
-@include oColorsSetUseCase(o-buttons-standard-pressedselected, border,     'teal-1');
-@include oColorsSetUseCase(o-buttons-standard-pressedselected, text,       'teal-1');
+// Theme: secondary
 
-/// Theme: Standard
-///
-/// @type Map
-$o-buttons-themes__standard: (
-	normal: (
-		color: oColorsGetColorFor(o-buttons-standard-normal, text),
-		background-color: oColorsGetColorFor(o-buttons-standard-normal, background),
-		border-color: rgba(oColorsGetColorFor(o-buttons-standard-normal, border), 0.4),
-	),
-	active: (
-		color: darken(oColorsGetColorFor(o-buttons-standard-active, text), 13%),
-		border-color: oColorsGetColorFor(o-buttons-standard-active, border),
-	),
-	hover: (
-		background-color: rgba(oColorsGetColorFor(o-buttons-standard-hover, background), 0.08),
-		border-color: rgba(oColorsGetColorFor(o-buttons-standard-hover, border), 0.5),
-	),
-	pressedselected: (
-		color: darken(oColorsGetColorFor(o-buttons-standard-active, text), 13%),
-		background-color: rgba(oColorsGetColorFor(o-buttons-standard-pressedselected, background), 0.4),
-		border-color: rgba(oColorsGetColorFor(o-buttons-standard-pressedselected, border), 0.5),
-	)
-) !default;
+@include oColorsSetUseCase(o-buttons-secondary-normal,   text,              'teal-50');
+@include oColorsSetUseCase(o-buttons-secondary-normal,   border,            'teal-50');
+@include oColorsSetUseCase(o-buttons-secondary-normal,   background,        'transparent');
+@include oColorsSetUseCase(o-buttons-secondary-hover,    text,              'white');
+@include oColorsSetUseCase(o-buttons-secondary-hover,    border,            'teal-50');
+@include oColorsSetUseCase(o-buttons-secondary-hover,    background,        'teal-50');
+@include oColorsSetUseCase(o-buttons-secondary-active,   text,              'teal-30');
+@include oColorsSetUseCase(o-buttons-secondary-active,   border,            'teal-80');
+@include oColorsSetUseCase(o-buttons-secondary-active,   background,        'teal-80');
+@include oColorsSetUseCase(o-buttons-secondary-pressedselected, text,       'teal-30');
+@include oColorsSetUseCase(o-buttons-secondary-pressedselected, border,     'teal-80');
+@include oColorsSetUseCase(o-buttons-secondary-pressedselected, background, 'teal-80');
 
-@include oColorsSetUseCase(o-buttons-standout-normal,   text,              'white');
-@include oColorsSetUseCase(o-buttons-standout-normal,   background,        'teal-1');
-@include oColorsSetUseCase(o-buttons-standout-hover,    border,            'teal-2');
-@include oColorsSetUseCase(o-buttons-standout-hover,    background,        'o-buttons-teal-3');
-@include oColorsSetUseCase(o-buttons-standout-pressedselected, background, 'teal-2');
-@include oColorsSetUseCase(o-buttons-standout-pressedselected, text,       'o-buttons-teal-4');
+// Theme: inverse
 
-/// Theme: Standout
-///
-/// @type Map
-$o-buttons-themes__standout: (
-	normal: (
-		color: oColorsGetColorFor(o-buttons-standout-normal, text),
-		background-color: oColorsGetColorFor(o-buttons-standout-normal, background),
-		border-color: oColorsGetColorFor(o-buttons-standout-normal, background),
-	),
-	active: (
-		color: darken(oColorsGetColorFor(o-buttons-standout-normal, text), 20%),
-		background-color: darken(oColorsGetColorFor(o-buttons-standout-normal, background), 10%) !important,
-	),
-	hover: (
-		color: oColorsGetColorFor(o-buttons-standout-normal, text),
-		background-color: darken(oColorsGetColorFor(o-buttons-standout-normal, background), 10%) !important,
-		border-color: darken(oColorsGetColorFor(o-buttons-standout-normal, background), 10%),
-	),
-	pressedselected: (
-		color: oColorsGetColorFor(o-buttons-standout-pressedselected, text),
-		background-color: oColorsGetColorFor(o-buttons-standout-pressedselected, background),
-		border-color: oColorsGetColorFor(o-buttons-standout-pressedselected, background),
-	),
-	disabled: (
-		// Looks like a standard disabled button
-		color: oColorsGetColorFor(o-buttons-standard-normal, text),
-		border-color: oColorsGetColorFor(o-buttons-standard-normal, border),
-	)
-) !default;
-
-@include oColorsSetUseCase(o-buttons-inverse-normal,   text,       'white');
-@include oColorsSetUseCase(o-buttons-inverse-normal,   background, 'transparent');
-@include oColorsSetUseCase(o-buttons-inverse-normal,   border,     'white');
-@include oColorsSetUseCase(o-buttons-inverse-active,   text,       'white');
-@include oColorsSetUseCase(o-buttons-inverse-hover,    background, 'black');
-@include oColorsSetUseCase(o-buttons-inverse-hover,    border,     'white');
+@include oColorsSetUseCase(o-buttons-inverse-normal,   text,              'white');
+@include oColorsSetUseCase(o-buttons-inverse-normal,   border,            'white');
+@include oColorsSetUseCase(o-buttons-inverse-normal,   background,        'transparent');
+@include oColorsSetUseCase(o-buttons-inverse-hover,    text,              'white');
+@include oColorsSetUseCase(o-buttons-inverse-hover,    border,            'white');
+@include oColorsSetUseCase(o-buttons-inverse-hover,    background,        'white-black-20');
+@include oColorsSetUseCase(o-buttons-inverse-active,   text,              'black');
+@include oColorsSetUseCase(o-buttons-inverse-active,   border,            'white');
+@include oColorsSetUseCase(o-buttons-inverse-active,   background,        'white');
+@include oColorsSetUseCase(o-buttons-inverse-pressedselected, text,       'black');
+@include oColorsSetUseCase(o-buttons-inverse-pressedselected, border,     'white');
 @include oColorsSetUseCase(o-buttons-inverse-pressedselected, background, 'white');
-@include oColorsSetUseCase(o-buttons-inverse-pressedselected, border, 'white');
-@include oColorsSetUseCase(o-buttons-inverse-pressedselected, text, 'black');
 
-/// Theme: Inverse
-///
-/// @type Map
-$o-buttons-themes__inverse: (
-	normal: (
-		color: oColorsGetColorFor(o-buttons-inverse-normal, text),
-		background: oColorsGetColorFor(o-buttons-inverse-normal, background),
-		border-color: rgba(oColorsGetColorFor(o-buttons-inverse-normal, border), 0.5),
-	),
-	active: (
-		color: oColorsGetColorFor(o-buttons-inverse-active, text),
-	),
-	hover: (
-		color: oColorsGetColorFor(o-buttons-inverse-active, text),
-		background-color: rgba(oColorsGetColorFor(o-buttons-inverse-hover, background), 0.4) !important,
-		border-color: rgba(oColorsGetColorFor(o-buttons-inverse-hover, border), 0.5),
-	),
-	pressedselected: (
-		color: oColorsGetColorFor(o-buttons-inverse-pressedselected, text),
-		background-color: oColorsGetColorFor(o-buttons-inverse-pressedselected, background),
-		border-color: oColorsGetColorFor(o-buttons-inverse-pressedselected, border),
-	)
-) !default;
+// Theme: mono
 
-@include oColorsSetUseCase(o-buttons-uncolored-normal, text,       'black');
-@include oColorsSetUseCase(o-buttons-uncolored-normal, background, 'transparent');
-@include oColorsSetUseCase(o-buttons-uncolored-normal, border,     'black');
-@include oColorsSetUseCase(o-buttons-uncolored-hover, background, 'black');
-@include oColorsSetUseCase(o-buttons-uncolored-pressedselected, background, 'black');
-@include oColorsSetUseCase(o-buttons-uncolored-pressedselected, border, 'black');
-@include oColorsSetUseCase(o-buttons-uncolored-pressedselected, text, 'white');
-@include oColorsSetUseCase(o-buttons-uncolored-disabled, background, 'transparent');
-@include oColorsSetUseCase(o-buttons-uncolored-disabled, text, 'black');
-@include oColorsSetUseCase(o-buttons-uncolored-disabled, border, 'black');
+@include oColorsSetUseCase(o-buttons-mono-normal,   text,              'black');
+@include oColorsSetUseCase(o-buttons-mono-normal,   border,            'black');
+@include oColorsSetUseCase(o-buttons-mono-normal,   background,        'transparent');
+@include oColorsSetUseCase(o-buttons-mono-hover,    text,              'black');
+@include oColorsSetUseCase(o-buttons-mono-hover,    border,            'white');
+@include oColorsSetUseCase(o-buttons-mono-hover,    background,        'black-10');
+@include oColorsSetUseCase(o-buttons-mono-active,   text,              'white');
+@include oColorsSetUseCase(o-buttons-mono-active,   border,            'black');
+@include oColorsSetUseCase(o-buttons-mono-active,   background,        'black');
+@include oColorsSetUseCase(o-buttons-mono-pressedselected, text,       'white');
+@include oColorsSetUseCase(o-buttons-mono-pressedselected, border,     'black');
+@include oColorsSetUseCase(o-buttons-mono-pressedselected, background, 'black');
 
+// Theme: B2C
 
-/// Theme: B2C
-///
-/// @type Map
-
-$o-buttons-themes__uncolored: (
-	normal: (
-		color: oColorsGetColorFor(o-buttons-uncolored-normal, text),
-		background-color: oColorsGetColorFor(o-buttons-uncolored-normal, background),
-		border-color: rgba(oColorsGetColorFor(o-buttons-uncolored-normal, border), 0.5),
-	),
-	active: (
-		border-color: oColorsGetColorFor(o-buttons-uncolored-pressedselected, border),
-	),
-	hover: (
-		background-color: rgba(oColorsGetColorFor(o-buttons-uncolored-hover, background), 0.1),
-		border-color: rgba(oColorsGetColorFor(o-buttons-uncolored-normal, border), 0.5),
-	),
-	pressedselected: (
-		background-color: oColorsGetColorFor(o-buttons-uncolored-pressedselected, background) !important,
-		color: oColorsGetColorFor(o-buttons-uncolored-pressedselected, text),
-		border-color: oColorsGetColorFor(o-buttons-uncolored-pressedselected, border),
-	),
-	disabled: (
-		color: rgba(oColorsGetColorFor(o-buttons-uncolored-disabled, text), 0.4),
-		border-color: rgba(oColorsGetColorFor(o-buttons-uncolored-disabled, background), 0.2),
-	)
-) !default;
-
-
-@include oColorsSetUseCase(o-buttons-b2c-normal, text,       'white');
-@include oColorsSetUseCase(o-buttons-b2c-normal, background, 'org-b2c-dark');
-@include oColorsSetUseCase(o-buttons-b2c-normal, border,     'org-b2c-dark');
-@include oColorsSetUseCase(o-buttons-b2c-hover, background, 'org-b2c');
-@include oColorsSetUseCase(o-buttons-b2c-hover, border, 'org-b2c-dark');
+@include oColorsSetUseCase(o-buttons-b2c-normal, text,                'white');
+@include oColorsSetUseCase(o-buttons-b2c-normal, background,          'org-b2c-dark');
+@include oColorsSetUseCase(o-buttons-b2c-normal, border,              'org-b2c-dark');
+@include oColorsSetUseCase(o-buttons-b2c-hover, text,                 'black-90');
+@include oColorsSetUseCase(o-buttons-b2c-hover, border,               'org-b2c-dark');
+@include oColorsSetUseCase(o-buttons-b2c-hover, background,           'org-b2c');
 @include oColorsSetUseCase(o-buttons-b2c-pressedselected, background, 'org-b2c-light');
-@include oColorsSetUseCase(o-buttons-b2c-pressedselected, border, 'org-b2c-light');
-@include oColorsSetUseCase(o-buttons-b2c-pressedselected, text, 'warm-4');
-@include oColorsSetUseCase(o-buttons-b2c-disabled, background, 'white');
-@include oColorsSetUseCase(o-buttons-b2c-disabled, text, 'org-b2c-dark');
+@include oColorsSetUseCase(o-buttons-b2c-pressedselected, border,     'org-b2c-light');
+@include oColorsSetUseCase(o-buttons-b2c-pressedselected, text,       'black-90');
+@include oColorsSetUseCase(o-buttons-b2c-active, text,                'black-90');
+@include oColorsSetUseCase(o-buttons-b2c-disabled, background,        'white');
+@include oColorsSetUseCase(o-buttons-b2c-disabled, text,              'org-b2c-dark');
 
 
 /// Theme: B2C
@@ -185,7 +100,6 @@ $o-buttons-themes__b2c: (
 		border-color: oColorsGetColorFor(o-buttons-b2c-pressedselected, border),
 	),
 	hover: (
-		// background-color: darken(oColorsGetColorFor(o-buttons-b2c-hover, background), 14),
 		background-color: rgba(oColorsGetColorFor(o-buttons-b2c-hover, background), 0.8),
 		color: oColorsGetColorFor(o-buttons-b2c-pressedselected, text),
 		border-color: oColorsGetColorFor(o-buttons-b2c-hover, border),

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -31,31 +31,22 @@ $o-buttons-font-weight: 600 !default; // Semibold
 ///
 /// @type Map
 $o-buttons-sizes: (
-	small: (
-		background-size: 12px,
-		font-size: 12px,
-		min-height: 22px,
-		min-width: 22px,
-		padding-left: 7px,
-		padding-right: 7px,
-		border-width: 1px,
-	),
-	medium: (
+	default: (
 		background-size: 16px,
 		font-size: 14px,
-		min-height: 26px,
-		min-width: 26px,
+		min-height: 28px,
+		min-width: 60px,
 		padding-left: 8px,
 		padding-right: 8px,
 		border-width: 1px,
 	),
 	big: (
-		background-size: 18px,
-		font-size: 18px,
-		min-height: 36px,
-		min-width: 36px,
-		padding-left: 18px,
-		padding-right: 18px,
+		background-size: 20px,
+		font-size: 16px,
+		min-height: 40px,
+		min-width: 80px,
+		padding-left: 20px,
+		padding-right: 20px,
 		border-width: 1px,
 	)
 ) !default;
@@ -71,10 +62,10 @@ $_o-buttons-border-radius: $o-normalise-border-radius;
 ///
 /// @type Map
 $o-buttons-themes: (
-	standard: $o-buttons-themes__standard,
-	standout: $o-buttons-themes__standout,
-	inverse: $o-buttons-themes__inverse,
-	uncolored: $o-buttons-themes__uncolored,
+	primary: 'primary',
+	secondary: 'secondary',
+	inverse: 'inverse',
+	mono: 'mono',
 	b2c: $o-buttons-themes__b2c
 ) !default;
 


### PR DESCRIPTION
Updates to the new o-colors version.
Removes small size and renames medium to default.
Renames standard, standout, and uncolored themes to secondary, primary, and mono respectively.
Removes deprecated code
Updates demos and adds migration guide.

Closes #113 
Closes #112 
Closes #111 
Closes #106 
Closes #114 

Before: 

![screen shot 2017-06-01 at 11 19 55](https://cloud.githubusercontent.com/assets/1240073/26675549/51854f66-46bc-11e7-98f2-722d96d55f95.png)
![screen shot 2017-06-01 at 11 19 59](https://cloud.githubusercontent.com/assets/1240073/26675546/5180aca4-46bc-11e7-8ce5-729596fa6c85.png)

After:

![screen shot 2017-06-01 at 11 19 23](https://cloud.githubusercontent.com/assets/1240073/26675547/518317be-46bc-11e7-901c-17bf87811bff.png)
![screen shot 2017-06-01 at 11 19 33](https://cloud.githubusercontent.com/assets/1240073/26675548/51836f70-46bc-11e7-8531-ad4266027316.png)
![screen shot 2017-06-01 at 11 20 10](https://cloud.githubusercontent.com/assets/1240073/26675545/517f104c-46bc-11e7-9baf-a0be49764c96.png)