### PR TITLE
Set high specificity no-decoration on hover

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -66,6 +66,7 @@
 	&:not([disabled]) {
 		&:hover {
 			@include _oButtonsPropertiesForState($theme, hover);
+			text-decoration: none;
 		}
 		&:active {
 			@include _oButtonsPropertiesForState($theme, active);


### PR DESCRIPTION
Where buttons are links not button elements, and where the document has a hover underline for links, this is interferring with the button styles.