### PR TITLE
Custom themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,15 +198,23 @@ Or, using Sass:
 
 #### Custom themes
 
-You can use the `oButtonsCustomTheme` mixin to create custom colored buttons using the oColors color variables.
+You can use the `oButtonsCustomTheme` mixin to create custom coloured buttons using the oColors color variables.
 
-eg to create a `lemon` on `slate` button:
+E.g. to create a `lemon` accented button on a `slate` background:
 
 ```scss
-	@include oButtonsCustomTheme(slate, lemon);
+@include oButtonsCustomTheme(slate, lemon);
 ```
 
-Where slate is the page colour, and lemon is the button colour.
+This will output styles for a slate coloured button that has lemon text and border, with a slate/lemon mixed hover state.
+
+To create a `lemon` _filled_ button on a `slate` background, use the `colorizer` parameter and set to `primary`:
+
+```scss
+@include oButtonsCustomTheme(slate, lemon, primary);
+```
+
+This will output styles for a lemon coloured button that has slate text, with a slate/lemon mixed hover state.
 
 #### Icons
 [View demo](https://origami-build.ft.com/demos/o-buttons/icons)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ o-buttons provides Sass mixins and variables to create buttons.
 
 o-buttons provides styling for:
 
-- **Themes**: `o-buttons--{primary|secondary|inverse|mono|b2c}` or `@include oButtonsTheme($theme)``
+- **Themes**: `o-buttons--{primary|secondary|inverse|mono|b2c}` or `@include oButtonsTheme($theme);`
+	- **Custom themes**: [Via mixins only] `@include oButtonsCustomTheme($page-background-color, $accent-color);`
 - **Sizes**: `o-buttons--{default|big}` or `@include oButtonsSize($size);`
 - **Grouped buttons**: `o-buttons-group` or `@include oButtonsGroup;`
 - **Pagination buttons**: `o-buttons-pagination` or `@include oButtonsPagination;`
@@ -194,6 +195,18 @@ Or, using Sass:
 
 <button class="my-secondary-button">Secondary button</button>
 ```
+
+#### Custom themes
+
+You can use the `oButtonsCustomTheme` mixin to create custom colored buttons using the oColors color variables.
+
+eg to create a `lemon` on `slate` button:
+
+```scss
+	@include oButtonsCustomTheme(slate, lemon);
+```
+
+Where slate is the page colour, and lemon is the button colour.
 
 #### Icons
 [View demo](https://origami-build.ft.com/demos/o-buttons/icons)

--- a/demos/src/custom.mustache
+++ b/demos/src/custom.mustache
@@ -1,33 +1,33 @@
 
 <div class="demo_custom-theme demo_custom-theme--slate">
-	<button class="o-buttons demo_custom-theme-button--slate-primary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-primary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-primary" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--slate-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-primary" disabled>Custom</button>
 </div>
 <div class="demo_custom-theme demo_custom-theme--slate">
-	<button class="o-buttons demo_custom-theme-button--slate-secondary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-secondary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-secondary" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--slate-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-secondary" disabled>Custom</button>
 </div>
 
 <div class="demo_custom-theme demo_custom-theme--teal">
-	<button class="o-buttons demo_custom-theme-button--teal-primary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-primary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-primary" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--teal-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-primary" disabled>Custom</button>
 </div>
 <div class="demo_custom-theme demo_custom-theme--teal">
-	<button class="o-buttons demo_custom-theme-button--teal-secondary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-secondary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-secondary" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--teal-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-secondary" disabled>Custom</button>
 </div>
 
 <div class="demo_custom-theme demo_custom-theme--lemon">
-	<button class="o-buttons demo_custom-theme-button--lemon-primary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-primary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-primary" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--lemon-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-primary" disabled>Custom</button>
 </div>
 <div class="demo_custom-theme demo_custom-theme--lemon">
-	<button class="o-buttons demo_custom-theme-button--lemon-secondary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-secondary">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-secondary" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--lemon-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-secondary" disabled>Custom</button>
 </div>

--- a/demos/src/custom.mustache
+++ b/demos/src/custom.mustache
@@ -1,15 +1,33 @@
+
 <div class="demo_custom-theme demo_custom-theme--slate">
-	<button class="o-buttons demo_custom-theme-button--slate">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--slate-primary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-primary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-primary" disabled>Inverse</button>
+</div>
+<div class="demo_custom-theme demo_custom-theme--slate">
+	<button class="o-buttons demo_custom-theme-button--slate-secondary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-secondary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-secondary" disabled>Inverse</button>
+</div>
+
+<div class="demo_custom-theme demo_custom-theme--teal">
+	<button class="o-buttons demo_custom-theme-button--teal-primary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-primary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-primary" disabled>Inverse</button>
 </div>
 <div class="demo_custom-theme demo_custom-theme--teal">
-	<button class="o-buttons demo_custom-theme-button--teal">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--teal-secondary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-secondary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-secondary" disabled>Inverse</button>
+</div>
+
+<div class="demo_custom-theme demo_custom-theme--lemon">
+	<button class="o-buttons demo_custom-theme-button--lemon-primary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-primary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-primary" disabled>Inverse</button>
 </div>
 <div class="demo_custom-theme demo_custom-theme--lemon">
-	<button class="o-buttons demo_custom-theme-button--lemon">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon">Inverse</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon" disabled>Inverse</button>
+	<button class="o-buttons demo_custom-theme-button--lemon-secondary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-secondary">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-secondary" disabled>Inverse</button>
 </div>

--- a/demos/src/custom.mustache
+++ b/demos/src/custom.mustache
@@ -1,0 +1,15 @@
+<div class="demo_custom-theme demo_custom-theme--slate">
+	<button class="o-buttons demo_custom-theme-button--slate">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate" disabled>Inverse</button>
+</div>
+<div class="demo_custom-theme demo_custom-theme--teal">
+	<button class="o-buttons demo_custom-theme-button--teal">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal" disabled>Inverse</button>
+</div>
+<div class="demo_custom-theme demo_custom-theme--lemon">
+	<button class="o-buttons demo_custom-theme-button--lemon">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon">Inverse</button>
+	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon" disabled>Inverse</button>
+</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -18,7 +18,37 @@ body {
 .faux-inline-block {
 	display: inline-block;
 }
-
 .inverse {
 	background-color: oColorsGetPaletteColor('slate');
+}
+
+.custom-button-theme-demo body {
+	margin:0;
+}
+
+.demo_custom-theme {
+	padding: 1em;
+}
+
+.demo_custom-theme--teal {
+	background-color: oColorsGetPaletteColor(teal-60);
+	padding: 1em;
+}
+.demo_custom-theme--slate {
+	background-color: oColorsGetPaletteColor(slate);
+	padding: 1em;
+}
+.demo_custom-theme--lemon {
+	background-color: oColorsGetPaletteColor(slate);
+	padding: 1em;
+}
+
+.demo_custom-theme-button--teal {
+	@include oButtonsCustomTheme(teal-60, 'white');
+}
+.demo_custom-theme-button--slate {
+	@include oButtonsCustomTheme(slate, 'white');
+}
+.demo_custom-theme-button--lemon {
+	@include oButtonsCustomTheme(slate, lemon);
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -43,12 +43,22 @@ body {
 	padding: 1em;
 }
 
-.demo_custom-theme-button--teal {
-	@include oButtonsCustomTheme(teal-60, 'white');
+.demo_custom-theme-button--teal-primary {
+	// @include oButtonsCustomTheme(teal-60, 'white', primary);
+	@include oButtonsCustomTheme(teal-60, 'white', primary);
 }
-.demo_custom-theme-button--slate {
-	@include oButtonsCustomTheme(slate, 'white');
+.demo_custom-theme-button--teal-secondary {
+	@include oButtonsCustomTheme(teal-60, 'white', secondary);
 }
-.demo_custom-theme-button--lemon {
-	@include oButtonsCustomTheme(slate, lemon);
+.demo_custom-theme-button--slate-primary {
+	@include oButtonsCustomTheme(slate, 'white', primary);
+}
+.demo_custom-theme-button--slate-secondary {
+	@include oButtonsCustomTheme(slate, 'white', secondary);
+}
+.demo_custom-theme-button--lemon-primary {
+	@include oButtonsCustomTheme(slate, lemon, primary);
+}
+.demo_custom-theme-button--lemon-secondary {
+	@include oButtonsCustomTheme(slate, lemon, secondary);
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -23,7 +23,7 @@ body {
 }
 
 .custom-button-theme-demo body {
-	margin:0;
+	margin: 0;
 }
 
 .demo_custom-theme {

--- a/origami.json
+++ b/origami.json
@@ -71,6 +71,13 @@
       "template": "/demos/src/pa11y.mustache",
       "hidden": true,
       "description": "Pa11y test for accesibility"
-    }
+    },
+		{
+			"name": "custom",
+			"template": "/demos/src/custom.mustache",
+			"hidden": true,
+			"bodyClasses": "custom-button-theme-demo",
+			"description": "Custom theme test"
+		}
   ]
 }

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -4,7 +4,7 @@
 ////
 
 /// Button size
-/// Ouputs dimensions for a specific button size
+/// Outputs dimensions for a specific button size
 ///
 /// @example
 /// .my-button--big {
@@ -45,7 +45,7 @@
 }
 
 /// Button theme construct
-/// Ouputs styles for all button states
+/// Outputs styles for all button states
 ///
 /// @example
 /// .my-button--standout {
@@ -76,7 +76,7 @@
 
 
 /// Button custom theme construct
-/// Ouputs styles for all button states for custom buttons based on a background color and an accent colour
+/// Outputs styles for all button states for custom buttons based on a background color and an accent colour
 ///
 /// @example
 /// .my-button--custom {

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -83,12 +83,20 @@
 /// 	@include oButtonsTheme(black, paper);
 /// }
 ///
-/// @param {String} $theme
-@mixin oButtonsCustomTheme($background, $accent) {
-	// normal
+/// @param {String} $background - The background colour of the theme. Must be a colour name from o-colors
+/// @param {String} $accent - The accent colour of the theme. Must be a colour name from o-colors
+/// @param {String} $colorizer - One of primary or secondary (default)
+@mixin oButtonsCustomTheme($background, $accent, $colorizer: secondary) {
+	$testContrast: oColorsCheckContrast(oColorsGetPaletteColor($background), oColorsGetPaletteColor($accent));
+
 	border-color: oColorsGetPaletteColor($accent);
-	color: oColorsGetPaletteColor($accent);
-	background-color: transparent;
+	@if $colorizer == secondary {
+		color: oColorsGetPaletteColor($accent);
+		background-color: oColorsGetPaletteColor($background);
+	} @else {
+		color: oColorsGetPaletteColor($background);
+		background-color: oColorsGetPaletteColor($accent);
+	}
 
 	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
 	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -74,6 +74,46 @@
 	}
 }
 
+
+/// Button custom theme construct
+/// Ouputs styles for all button states for custom buttons based on a background color and an accent colour
+///
+/// @example
+/// .my-button--custom {
+/// 	@include oButtonsTheme(black, paper);
+/// }
+///
+/// @param {String} $theme
+@mixin oButtonsCustomTheme($background, $accent) {
+	// normal
+	border-color: oColorsGetPaletteColor($accent);
+	color: oColorsGetPaletteColor($accent);
+	background-color: transparent;
+
+	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
+	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
+	&[aria-selected=true], // e.g. A selected tab or page number in pagination
+	&[aria-pressed=true] { // e.g. A "follow" button that is pressed
+		border-color: oColorsGetPaletteColor($accent);
+		background-color: oColorsGetPaletteColor($accent);
+		color: oColorsGetPaletteColor($background);
+	}
+
+	&:not([disabled]) {
+		&:hover {
+			background-color: oColorsMix($background, $accent);
+			text-decoration: none;
+			border-color: oColorsGetPaletteColor($accent);
+			color: oColorsGetPaletteColor($accent);
+
+		}
+		&:active {
+			background-color: oColorsGetPaletteColor($accent);
+			color: oColorsGetPaletteColor($background);
+		}
+	}
+}
+
 /// Button construct
 /// Basic button styling and default states for specific theme and size
 ///

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -76,15 +76,15 @@
 
 
 /// Button custom theme construct
-/// Outputs styles for all button states for custom buttons based on a background color and an accent colour
+/// Outputs styles for all button states for custom buttons based on a background color and an accent color
 ///
 /// @example
 /// .my-button--custom {
 /// 	@include oButtonsTheme(black, paper);
 /// }
 ///
-/// @param {String} $background - The background colour of the theme. Must be a colour name from o-colors
-/// @param {String} $accent - The accent colour of the theme. Must be a colour name from o-colors
+/// @param {String} $background - The background color of the theme. Must be a color name from o-colors
+/// @param {String} $accent - The accent color of the theme. Must be a color name from o-colors
 /// @param {String} $colorizer - One of primary or secondary (default)
 @mixin oButtonsCustomTheme($background, $accent, $colorizer: secondary) {
 	$testContrast: oColorsCheckContrast(oColorsGetPaletteColor($background), oColorsGetPaletteColor($accent));


### PR DESCRIPTION
This PR adds in the ability to create custom button themes using o-colors palette colours. This does not switch mono and inverse themes to use the new mixins, as [this constitutes a breaking change](https://github.com/Financial-Times/o-buttons/issues/125).

The following docs are copied from the README, and I've included a screen-grab of the demo page for comparison with the design.


## Documentation

You can use the `oButtonsCustomTheme` mixin to create custom coloured buttons using the oColors color variables.

E.g. to create a `lemon` accented button on a `slate` background:

```scss
@include oButtonsCustomTheme(slate, lemon);
```

This will output styles for a slate coloured button that has lemon text and border, with a slate/lemon mixed hover state.

To create a `lemon` _filled_ button on a `slate` background, use the `colorizer` parameter and set to `primary`:

```scss
@include oButtonsCustomTheme(slate, lemon, primary);
```

This will output styles for a lemon coloured button that has slate text, with a slate/lemon mixed hover state.


## Demo

<img width="276" alt="Custom themed buttons demo" src="https://user-images.githubusercontent.com/138944/28566052-edda4df6-7125-11e7-943e-3dfc9f372c6d.png">
