### PR TITLE
Correct the custom theme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ You can use the `oButtonsCustomTheme` mixin to create custom coloured buttons us
 E.g. to create a `lemon` accented button on a `slate` background:
 
 ```scss
-@include oButtonsCustomTheme(slate, lemon);
+@include oButtonsCustomTheme('slate', 'lemon');
 ```
 
 This will output styles for a slate coloured button that has lemon text and border, with a slate/lemon mixed hover state.
@@ -211,7 +211,7 @@ This will output styles for a slate coloured button that has lemon text and bord
 To create a `lemon` _filled_ button on a `slate` background, use the `colorizer` parameter and set to `primary`:
 
 ```scss
-@include oButtonsCustomTheme(slate, lemon, primary);
+@include oButtonsCustomTheme('slate', 'lemon', primary);
 ```
 
 This will output styles for a lemon coloured button that has slate text, with a slate/lemon mixed hover state.

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -44,21 +44,20 @@ body {
 }
 
 .demo_custom-theme-button--teal-primary {
-	// @include oButtonsCustomTheme(teal-60, 'white', primary);
-	@include oButtonsCustomTheme(teal-60, 'white', primary);
+	@include oButtonsCustomTheme('teal-60', 'white', primary);
 }
 .demo_custom-theme-button--teal-secondary {
-	@include oButtonsCustomTheme(teal-60, 'white', secondary);
+	@include oButtonsCustomTheme('teal-60', 'white', secondary);
 }
 .demo_custom-theme-button--slate-primary {
-	@include oButtonsCustomTheme(slate, 'white', primary);
+	@include oButtonsCustomTheme('slate', 'white', primary);
 }
 .demo_custom-theme-button--slate-secondary {
-	@include oButtonsCustomTheme(slate, 'white', secondary);
+	@include oButtonsCustomTheme('slate', 'white', secondary);
 }
 .demo_custom-theme-button--lemon-primary {
-	@include oButtonsCustomTheme(slate, lemon, primary);
+	@include oButtonsCustomTheme('slate', 'lemon', primary);
 }
 .demo_custom-theme-button--lemon-secondary {
-	@include oButtonsCustomTheme(slate, lemon, secondary);
+	@include oButtonsCustomTheme('slate', 'lemon', secondary);
 }


### PR DESCRIPTION
It's safer to always quote colour names as "white" and others don't work
when unquoted. I've reflected this in the docs, as it tripped me up
while I was using custom buttons in o-banner.

This way is also a little more consistent.