### PR TITLE
Update button colours.

### DIFF
--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -3,8 +3,11 @@
 /// @link http://registry.origami.ft.com/components/o-buttons
 ////
 
-// Set custom color white over slate @ 20%
-@include oColorsSetColor('white-slate-20', oColorsMix($color: 'white', $background: 'slate', $percentage: 20));
+// @deprecated Set custom color white over slate @ 20%. 
+// This originally used black rather than slate, hence the misleading name to avoid a breaking change.
+// Updating this with an abstract name on the next major release will remove ambiguity and be more flexible.
+@include oColorsSetColor('white-black-20', oColorsMix($color: 'white', $background: 'slate', $percentage: 20));
+// @deprecated
 
 // Set custom color translucent teal @ 10%
 @include oColorsSetColor('teal-transparent-10', oColorsMix($color: 'teal', $background: 'transparent', $percentage: 10));
@@ -48,7 +51,7 @@
 @include oColorsSetUseCase(o-buttons-inverse-normal,   background,        'transparent');
 @include oColorsSetUseCase(o-buttons-inverse-hover,    text,              'white');
 @include oColorsSetUseCase(o-buttons-inverse-hover,    border,            'white');
-@include oColorsSetUseCase(o-buttons-inverse-hover,    background,        'white-slate-20');
+@include oColorsSetUseCase(o-buttons-inverse-hover,    background,        'white-black-20');
 @include oColorsSetUseCase(o-buttons-inverse-active,   text,              'black');
 @include oColorsSetUseCase(o-buttons-inverse-active,   border,            'white');
 @include oColorsSetUseCase(o-buttons-inverse-active,   background,        'white');

--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -3,8 +3,8 @@
 /// @link http://registry.origami.ft.com/components/o-buttons
 ////
 
-// Set custom color white over black @ 30%
-@include oColorsSetColor('white-black-30', oColorsMix($color: 'white', $background: 'black', $percentage: 30));
+// Set custom color white over slate @ 20%
+@include oColorsSetColor('white-slate-20', oColorsMix($color: 'white', $background: 'slate', $percentage: 20));
 
 // Set custom color translucent teal @ 10%
 @include oColorsSetColor('teal-transparent-10', oColorsMix($color: 'teal', $background: 'transparent', $percentage: 10));
@@ -48,7 +48,7 @@
 @include oColorsSetUseCase(o-buttons-inverse-normal,   background,        'transparent');
 @include oColorsSetUseCase(o-buttons-inverse-hover,    text,              'white');
 @include oColorsSetUseCase(o-buttons-inverse-hover,    border,            'white');
-@include oColorsSetUseCase(o-buttons-inverse-hover,    background,        'white-black-30');
+@include oColorsSetUseCase(o-buttons-inverse-hover,    background,        'white-slate-20');
 @include oColorsSetUseCase(o-buttons-inverse-active,   text,              'black');
 @include oColorsSetUseCase(o-buttons-inverse-active,   border,            'white');
 @include oColorsSetUseCase(o-buttons-inverse-active,   background,        'white');

--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -3,8 +3,11 @@
 /// @link http://registry.origami.ft.com/components/o-buttons
 ////
 
-// Set custom color white over black @ 20%
-@include oColorsSetColor('white-black-20', oColorsMix($color: 'white', $background: 'black', $percentage: 20));
+// Set custom color white over black @ 30%
+@include oColorsSetColor('white-black-30', oColorsMix($color: 'white', $background: 'black', $percentage: 30));
+
+// Set custom color translucent teal @ 10%
+@include oColorsSetColor('teal-transparent-10', oColorsMix($color: 'teal', $background: 'transparent', $percentage: 10));
 
 /// scss-lint:disable SpaceAfterComma
 
@@ -14,29 +17,29 @@
 @include oColorsSetUseCase(o-buttons-primary-normal,   border,            'teal-50');
 @include oColorsSetUseCase(o-buttons-primary-normal,   background,        'teal-50');
 @include oColorsSetUseCase(o-buttons-primary-hover,    text,              'white');
-@include oColorsSetUseCase(o-buttons-primary-hover,    border,            'teal-30');
-@include oColorsSetUseCase(o-buttons-primary-hover,    background,        'teal-30');
-@include oColorsSetUseCase(o-buttons-primary-active,   text,              'teal-30');
-@include oColorsSetUseCase(o-buttons-primary-active,   border,            'teal-80');
-@include oColorsSetUseCase(o-buttons-primary-active,   background,        'teal-80');
-@include oColorsSetUseCase(o-buttons-primary-pressedselected, text,       'teal-30');
-@include oColorsSetUseCase(o-buttons-primary-pressedselected, border,     'teal-80');
-@include oColorsSetUseCase(o-buttons-primary-pressedselected, background, 'teal-80');
+@include oColorsSetUseCase(o-buttons-primary-hover,    border,            'teal-40');
+@include oColorsSetUseCase(o-buttons-primary-hover,    background,        'teal-40');
+@include oColorsSetUseCase(o-buttons-primary-active,   text,              'white');
+@include oColorsSetUseCase(o-buttons-primary-active,   border,            'teal-30');
+@include oColorsSetUseCase(o-buttons-primary-active,   background,        'teal-30');
+@include oColorsSetUseCase(o-buttons-primary-pressedselected, text,       'white');
+@include oColorsSetUseCase(o-buttons-primary-pressedselected, border,     'teal-30');
+@include oColorsSetUseCase(o-buttons-primary-pressedselected, background, 'teal-30');
 
 // Theme: secondary
 
 @include oColorsSetUseCase(o-buttons-secondary-normal,   text,              'teal-50');
 @include oColorsSetUseCase(o-buttons-secondary-normal,   border,            'teal-50');
 @include oColorsSetUseCase(o-buttons-secondary-normal,   background,        'transparent');
-@include oColorsSetUseCase(o-buttons-secondary-hover,    text,              'white');
+@include oColorsSetUseCase(o-buttons-secondary-hover,    text,              'teal-50');
 @include oColorsSetUseCase(o-buttons-secondary-hover,    border,            'teal-50');
-@include oColorsSetUseCase(o-buttons-secondary-hover,    background,        'teal-50');
-@include oColorsSetUseCase(o-buttons-secondary-active,   text,              'teal-30');
-@include oColorsSetUseCase(o-buttons-secondary-active,   border,            'teal-80');
-@include oColorsSetUseCase(o-buttons-secondary-active,   background,        'teal-80');
-@include oColorsSetUseCase(o-buttons-secondary-pressedselected, text,       'teal-30');
-@include oColorsSetUseCase(o-buttons-secondary-pressedselected, border,     'teal-80');
-@include oColorsSetUseCase(o-buttons-secondary-pressedselected, background, 'teal-80');
+@include oColorsSetUseCase(o-buttons-secondary-hover,    background,        'teal-transparent-10');
+@include oColorsSetUseCase(o-buttons-secondary-active,   text,              'white');
+@include oColorsSetUseCase(o-buttons-secondary-active,   border,            'teal-50');
+@include oColorsSetUseCase(o-buttons-secondary-active,   background,        'teal-50');
+@include oColorsSetUseCase(o-buttons-secondary-pressedselected, text,       'white');
+@include oColorsSetUseCase(o-buttons-secondary-pressedselected, border,     'teal-50');
+@include oColorsSetUseCase(o-buttons-secondary-pressedselected, background, 'teal-50');
 
 // Theme: inverse
 
@@ -45,7 +48,7 @@
 @include oColorsSetUseCase(o-buttons-inverse-normal,   background,        'transparent');
 @include oColorsSetUseCase(o-buttons-inverse-hover,    text,              'white');
 @include oColorsSetUseCase(o-buttons-inverse-hover,    border,            'white');
-@include oColorsSetUseCase(o-buttons-inverse-hover,    background,        'white-black-20');
+@include oColorsSetUseCase(o-buttons-inverse-hover,    background,        'white-black-30');
 @include oColorsSetUseCase(o-buttons-inverse-active,   text,              'black');
 @include oColorsSetUseCase(o-buttons-inverse-active,   border,            'white');
 @include oColorsSetUseCase(o-buttons-inverse-active,   background,        'white');
@@ -59,7 +62,7 @@
 @include oColorsSetUseCase(o-buttons-mono-normal,   border,            'black');
 @include oColorsSetUseCase(o-buttons-mono-normal,   background,        'transparent');
 @include oColorsSetUseCase(o-buttons-mono-hover,    text,              'black');
-@include oColorsSetUseCase(o-buttons-mono-hover,    border,            'white');
+@include oColorsSetUseCase(o-buttons-mono-hover,    border,            'black');
 @include oColorsSetUseCase(o-buttons-mono-hover,    background,        'black-10');
 @include oColorsSetUseCase(o-buttons-mono-active,   text,              'white');
 @include oColorsSetUseCase(o-buttons-mono-active,   border,            'black');


### PR DESCRIPTION
**changes**

- Tweak the primary and secondary theme's teal tint, particularly the active state.
- Introduce a translucent hover state for the secondary theme.
- Update the inverse theme hover state to be lighter.
- Update the mono theme hover state border to be black.

If I'm not mistaken, the hover state of the translucent secondary button passes our accessibility guidelines when placed on `paper` but not on `wheat`. Suggestions here would be welcome.
wheat 4.1: http://leaverou.github.io/contrast-ratio/#%230d7680-on-%23f2dfce
paper 4.2: http://leaverou.github.io/contrast-ratio/#%230d7680-on-%23E5E4DB

Designs may be previewed on the issue: https://github.com/Financial-Times/o-buttons/issues/120

**qa thoughts**

- Implementation (new custom colour with translucency)?
- Accessibility?
- Impact on clients and dependent components?
- Match to the design (I did not have access to the sketch file)?

**screenshot**

primary
![button-primary](https://user-images.githubusercontent.com/10405691/29718061-61c7f74a-89a9-11e7-83d1-de920a0c87b3.gif)

secondary
![button-secondary](https://user-images.githubusercontent.com/10405691/29718086-76e686f0-89a9-11e7-903a-58b4a6c55fdc.gif)

mono
![button-mono](https://user-images.githubusercontent.com/10405691/29718069-69387bd0-89a9-11e7-8fe2-bc4b358a92b9.gif)

inverse
![button-inverse](https://user-images.githubusercontent.com/10405691/29718076-6df08ed8-89a9-11e7-8ab7-549c1090ac0c.gif)

tab buttons primary (example dependant impacted)
![buttontabs-primary](https://user-images.githubusercontent.com/10405691/29718104-817b7332-89a9-11e7-93ff-8d7e2ea8e16c.gif)

tab buttons (example dependant impacted)
![buttontabs](https://user-images.githubusercontent.com/10405691/29718133-986a79c6-89a9-11e7-8545-1987cf5f3d1f.gif)
