### PR TITLE
Add icon buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,10 @@ To create a `lemon` _filled_ button on a `slate` background, use the `colorizer`
 This will output styles for a lemon coloured button that has slate text, with a slate/lemon mixed hover state.
 
 #### Icons
-[View demo](https://origami-build.ft.com/demos/o-buttons/icons)
+o-buttons uses the [fticons](https://registry.origami.ft.com/components/fticons/) set via the [o-icons](https://github.com/Financial-Times/o-icons/) mixins for its icon-buttons.
 
-o-buttons uses [fticons](https://registry.origami.ft.com/components/fticons/) via the [o-icons](https://github.com/Financial-Times/o-icons/) mixins for its icon-buttons.
+If you're using the Build Service, currently supported icons are defined in the `$o-buttons-icons` variable in `scss/_variables.scss`. Limiting the concrete classes keeps the compiled CSS bundle small, but if you need an icon button that we don't currently support then please open an issue.
+If you're using the mixins, all [fticons](https://registry.origami.ft.com/components/fticons/) will work.
 
 ```html
 // Icon and text button.

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -7,8 +7,17 @@ html {
 }
 
 body {
-	font-family: FinancierDisplayWeb, serif;
+	font-family: Metric, serif;
 	margin: 1em;
+}
+
+h2 {
+	font-weight: 400;
+}
+
+p {
+	max-width: 900px;
+	font-size: 18px;
 }
 
 .test-page {
@@ -17,6 +26,14 @@ body {
 
 .faux-inline-block {
 	display: inline-block;
+}
+
+.theme-box {
+	display: inline-block;
+	padding: 10px;
+	margin-left: -10px;
+	margin-right: 10px;
+
 }
 .inverse {
 	background-color: oColorsGetPaletteColor('slate');

--- a/demos/src/icons.json
+++ b/demos/src/icons.json
@@ -1,0 +1,34 @@
+{
+  "icons": [
+    {
+      "name": "plus",
+      "text": "Add to myFT"
+    },
+    {
+      "name": "tick",
+      "text": "Added"
+    },
+    {
+      "name": "arrow-left",
+      "text": "Go forward"
+    },
+    {
+      "name": "arrow-right",
+      "text": "Go back"
+    },
+    {
+      "name": "upload",
+      "text": "Upload"
+    }
+  ],
+  "themes": [
+      {"name": "primary"},
+      {"name": "secondary"},
+      {"name": "mono"},
+      {"name": "inverse"}
+    ],
+  "sizes": [
+      {"name": "small"},
+      {"name": "big"}
+  ]
+}

--- a/demos/src/icons.json
+++ b/demos/src/icons.json
@@ -1,34 +1,34 @@
 {
-  "icons": [
-    {
-      "name": "plus",
-      "text": "Add to myFT"
-    },
-    {
-      "name": "tick",
-      "text": "Added"
-    },
-    {
-      "name": "arrow-left",
-      "text": "Go forward"
-    },
-    {
-      "name": "arrow-right",
-      "text": "Go back"
-    },
-    {
-      "name": "upload",
-      "text": "Upload"
-    }
-  ],
-  "themes": [
-      {"name": "primary"},
-      {"name": "secondary"},
-      {"name": "mono"},
-      {"name": "inverse"}
-    ],
-  "sizes": [
-      {"name": "small"},
-      {"name": "big"}
-  ]
+	"icons": [
+		{
+			"name": "plus",
+			"text": "Add to myFT"
+		},
+		{
+			"name": "tick",
+			"text": "Added"
+		},
+		{
+			"name": "arrow-left",
+			"text": "Go forward"
+		},
+		{
+			"name": "arrow-right",
+			"text": "Go back"
+		},
+		{
+			"name": "upload",
+			"text": "Upload"
+		}
+	],
+	"themes": [
+			{"name": "primary"},
+			{"name": "secondary"},
+			{"name": "mono"},
+			{"name": "inverse"}
+		],
+	"sizes": [
+			{"name": "small"},
+			{"name": "big"}
+	]
 }

--- a/demos/src/icons.mustache
+++ b/demos/src/icons.mustache
@@ -4,12 +4,12 @@
   <button class="o-buttons o-buttons--small o-buttons-icon o-buttons-icon--arrow-left">Go back</button>
   <br>
   <br>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--uncolored o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--uncolored o-buttons-icon--arrow-left">Go back</button>
+  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--mono o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
+  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--mono o-buttons-icon--arrow-left">Go back</button>
   <br>
   <br>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--standout o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--standout o-buttons-icon--arrow-left">Go back</button>
+  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--primary o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
+  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--primary o-buttons-icon--arrow-left">Go back</button>
 </div>
 <div class='demo-block inverse'>
   <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--inverse o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>

--- a/demos/src/icons.mustache
+++ b/demos/src/icons.mustache
@@ -1,49 +1,45 @@
+<h2>Currently supported icons</h2>
+<p>You can add any icon using the <code>oButtonsGetButtonForIconAndTheme</code> mixin. If you need an icon button with the build service, please ask the team or raise a PR adding the o-icons icon to the <code>$o-buttons-icons</code> variable.</p>
+	{{#icons}}
+		<button class="o-buttons o-buttons-icon o-buttons-icon--{{name}}">
+			{{text}}
+		</button>
+	{{/icons}}
+	<br>
+	<br>
+	{{#icons}}
+		<button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--{{name}}">
+			{{text}}
+		</button>
+	{{/icons}}
+<h2>Icon buttons without text</h2>
+{{#icons}}
+<button class="o-buttons o-buttons-icon o-buttons-icon--{{name}} o-buttons-icon--icon-only">
+	<span class="o-buttons-icon__label">{{text}}</span>
+</button>
+{{/icons}}
+<br>
+<br>
+{{#icons}}
+<button class="o-buttons o-buttons-icon o-buttons--big o-buttons-icon--{{name}} o-buttons-icon--icon-only">
+	<span class="o-buttons-icon__label">{{text}}</span>
+</button>
+{{/icons}}
 
-<div class="demo-block">
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons-icon--arrow-left">Go back</button>
-  <br>
-  <br>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--mono o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--mono o-buttons-icon--arrow-left">Go back</button>
-  <br>
-  <br>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--primary o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--primary o-buttons-icon--arrow-left">Go back</button>
-</div>
-<div class='demo-block inverse'>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--inverse o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--small o-buttons-icon o-buttons--inverse o-buttons-icon--arrow-left">Go back</button>
-</div>
-<div class="demo-block">
-  <button class="o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons-icon o-buttons-icon--arrow-left">Go back</button>
-  <br>
-  <br>
-  <button class="o-buttons o-buttons-icon o-buttons--uncolored o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons-icon o-buttons--uncolored o-buttons-icon--arrow-left">Go back</button>
-  <br>
-  <br>
-  <button class="o-buttons o-buttons-icon o-buttons--standout o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons-icon o-buttons--standout o-buttons-icon--arrow-left">Go back</button>
-</div>
-<div class="demo-block inverse">
-  <button class="o-buttons o-buttons-icon o-buttons--inverse o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons-icon o-buttons--inverse o-buttons-icon--arrow-left">Go back</button>
-</div>
-<div class="demo-block">
-  <button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left">Go back</button>
-  <br>
-  <br>
-  <button class="o-buttons o-buttons--big o-buttons-icon o-buttons--uncolored o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--big o-buttons-icon o-buttons--uncolored o-buttons-icon--arrow-left">Go back</button>
-  <br>
-  <br>
-  <button class="o-buttons o-buttons--big o-buttons-icon o-buttons--standout o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-  <button class="o-buttons o-buttons--big o-buttons-icon o-buttons--standout o-buttons-icon--arrow-left">Go back</button>
-</div>
-<div class="demo-block inverse">
-<button class="o-buttons o-buttons--big o-buttons-icon o-buttons--inverse o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class="o-buttons-icon__label">Go back</span></button>
-<button class="o-buttons o-buttons--big o-buttons-icon o-buttons--inverse o-buttons-icon--arrow-left">Go back</button>
-</div>
+<h2>Icon buttons with different themes</h2>
+	{{#themes}}
+		<div class='theme-box {{name}}'>
+			<button class="o-buttons o-buttons--{{name}} o-buttons-icon o-buttons-icon--plus">
+				Add to myFT
+			</button>
+		</div>
+	{{/themes}}
+	<br>
+	</br>
+	{{#themes}}
+		<div class='theme-box {{name}}'>
+			<button class="o-buttons o-buttons--big o-buttons--{{name}} o-buttons-icon o-buttons-icon--plus">
+				Add to myFT
+			</button>
+		</div>
+	{{/themes}}

--- a/origami.json
+++ b/origami.json
@@ -58,7 +58,7 @@
       "name": "grouped",
       "title": "Grouped layout",
       "template": "/demos/src/grouped.mustache",
-      "description": "For button layouts were there is a choice of related options. This layout can be combined with themes for example o-buttons--b2c."
+      "description": "For button layouts where there is a choice of related options. This layout can be combined with themes for example o-buttons--b2c."
     },
     {
       "name": "icons",

--- a/origami.json
+++ b/origami.json
@@ -61,6 +61,13 @@
       "description": "For button layouts were there is a choice of related options. This layout can be combined with themes for example o-buttons--b2c."
     },
     {
+      "name": "icons",
+      "title": "Grouped layout",
+      "template": "/demos/src/icons.mustache",
+      "data": "demos/src/icons.json",
+      "description": "For button layouts were there is a choice of related options. This layout can be combined with themes for example o-buttons--b2c."
+    },
+    {
       "name": "test",
       "template": "/demos/src/test.mustache",
       "hidden": true,

--- a/origami.json
+++ b/origami.json
@@ -62,10 +62,10 @@
     },
     {
       "name": "icons",
-      "title": "Grouped layout",
+      "title": "Icon buttons",
       "template": "/demos/src/icons.mustache",
       "data": "demos/src/icons.json",
-      "description": "For button layouts were there is a choice of related options. This layout can be combined with themes for example o-buttons--b2c."
+      "description": "oButtons includes styles for some common icon buttons and the ability to add more using Sass mixins."
     },
     {
       "name": "test",

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -55,7 +55,6 @@
 			}
 
 			&:not([disabled]) {
-				&:focus:not(:hover),
 				&:hover {
 					@include _oButtonsGetIconForThemeAndState($icon-name, $theme, hover);
 				}

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -82,6 +82,10 @@
 	background-position: 3px;
 	padding-left: 22px;
 
+	&.o-buttons--big {
+		padding-left: 40px;
+	}
+
 	&.o-buttons-icon--icon-only {
 		padding-left: 0;
 		background-position: 50%;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -76,4 +76,4 @@ $o-buttons-themes: (
 /// Icon names as used in fticons
 ///
 /// @type List
-$o-buttons-icons: "arrow-left", "arrow-right" !default;
+$o-buttons-icons: "arrow-left", "arrow-right", "upload", "tick", "plus" !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -32,7 +32,7 @@ $o-buttons-font-weight: 600 !default; // Semibold
 /// @type Map
 $o-buttons-sizes: (
 	default: (
-		background-size: 16px,
+		background-size: 21px, // Magic number to reduce poor antialiasing on icons at small sizes
 		font-size: 14px,
 		min-height: 28px,
 		min-width: 60px,
@@ -41,7 +41,7 @@ $o-buttons-sizes: (
 		border-width: 1px,
 	),
 	big: (
-		background-size: 20px,
+		background-size: 40px,
 		font-size: 16px,
 		min-height: 40px,
 		min-width: 80px,


### PR DESCRIPTION
@wheresrhys, @fenglish, @Lily2point0 I've made a PR which:

- Adds back in the icons demo
- Clarifies the concrete classes vs mixins ways of including an icon in a button
- Adds some new concrete icon buttons (upload, tick and plus)
- Changes the size of the big icons (to 40px)

Here's a screengrab of the demo:
![screen shot 2017-08-31 at 15 35 22](https://user-images.githubusercontent.com/68009/29928927-153bd492-8e62-11e7-9297-87cf3d16ad40.png)
