### PR TITLE
Add up and down icons to icon buttons

### DIFF
--- a/demos/src/icons.json
+++ b/demos/src/icons.json
@@ -23,6 +23,14 @@
 		{
 			"name": "warning",
 			"text": "Danger"
+		},
+		{
+			"name": "arrow-down",
+			"text": "Show"
+		},
+		{
+			"name": "arrow-up",
+			"text": "Hide"
 		}
 	],
 	"themes": [

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -76,4 +76,4 @@ $o-buttons-themes: (
 /// Icon names as used in fticons
 ///
 /// @type List
-$o-buttons-icons: "arrow-left", "arrow-right", "upload", "tick", "plus", "warning" !default;
+$o-buttons-icons: "arrow-left", "arrow-right", "upload", "tick", "plus", "warning", "arrow-down", "arrow-up" !default;


### PR DESCRIPTION
These up/down arrow icons would be useful in hide / show situations. 
They currently look like this: 

<img width="852" alt="screen shot 2017-09-25 at 11 36 51" src="https://user-images.githubusercontent.com/10324129/30804577-dee02c1c-a1e5-11e7-898e-f1ccb9d1c2d1.png">


@olipowell - do the up/down arrows look okay to you? 