### PR TITLE
Rework icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ o-buttons provides styling for:
 - **Sizes**: `o-buttons--{default|big}` or `@include oButtonsSize($size);`
 - **Grouped buttons**: `o-buttons-group` or `@include oButtonsGroup;`
 - **Pagination buttons**: `o-buttons-pagination` or `@include oButtonsPagination;`
-- **Icon buttons**: `o-buttons-icon o-buttons-icon--{arrow-left| arrow-right}` or `@include oButtonsGetButtonForIconAndTheme($icon-name, $theme);`
+- **Icon buttons**: `o-buttons-icon o-buttons-icon--{arrow-left| arrow-right | other supported icon}` or `@include oButtonsIconButton($icon-name, $size, $theme);`
 
 You can combine these styles.
 
@@ -33,11 +33,11 @@ For detailed documentation on this component's mixins, see the [Sassdoc](http://
 
 ### Markup
 
-The button CSS will work on `<button>` or `<a>` elements. It is important for accessibility that if you intent to style an `<a>` as a button, you give it the correct [aria role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role).
+The button CSS will work on `<button>` or `<a>` elements. It is important for accessibility that if you intend to style an `<a>` as a button, you give it the correct [aria role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role).
 
 ### Sass
 
-Mixins and [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles) are only available if you're including o-buttons in your project using bower. If you're using o-buttons via the [Build Service](https://www.ft.com/__origami/service/build/v2/), you must use the o-buttons classes instead. Both are documented below.
+Mixins, Custom themes and [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles) are only available if you're including o-buttons in your project using bower. If you're using o-buttons via the [Build Service](https://www.ft.com/__origami/service/build/v2/), you must use the o-buttons classes instead. Both are documented below.
 
 #### Default button
 
@@ -217,10 +217,9 @@ To create a `lemon` _filled_ button on a `slate` background, use the `colorizer`
 This will output styles for a lemon coloured button that has slate text, with a slate/lemon mixed hover state.
 
 #### Icons
-o-buttons uses the [fticons](https://registry.origami.ft.com/components/fticons/) set via the [o-icons](https://github.com/Financial-Times/o-icons/) mixins for its icon-buttons.
+If you're using bower, you can create an icon button for **any** icon in [fticons](https://registry.origami.ft.com/components/fticons/).
 
 If you're using the Build Service, currently supported icons are defined in the `$o-buttons-icons` variable in `scss/_variables.scss`. Limiting the concrete classes keeps the compiled CSS bundle small, but if you need an icon button that we don't currently support then please open an issue.
-If you're using the mixins, all [fticons](https://registry.origami.ft.com/components/fticons/) will work.
 
 ```html
 // Icon and text button.
@@ -237,33 +236,25 @@ If you're using the mixins, all [fticons](https://registry.origami.ft.com/compon
 Or, using Sass:
 
 ```scss
-.my-button-class {
-	@include oButtons();
-}
-
 .my-button-class--icon {
-	// Generic sizing / padding for icon-buttons
-	@include oButtonsBaseStyles;
+ @include oButtons();
+ @include oButtonsIconButton(star);
 }
 
-.my-button-class--icon-star {
-	// icon here can be *any* icon tag (eg arrow-left) in fticons
-	@include oButtonsGetButtonForIconAndTheme(star, secondary);
-}
-
-.my-button-class-icon__label {
-	@include oButtonsIconButtonLabel;
+.my-button-class--icon-only {
+ @include oButtons();
+ @include oButtonsIconButton(star);
 }
 ```
 
 ```html
 // Icon and text button.
-<button class="my-button-class my-button-class--icon my-button-class--icon-star">star</button>
+<button class="my-button-class--icon">star</button>
 
 
 // Icon only button
-<button class="my-button-class my-button-class--icon my-button-class--icon-star">
-	// accessible text fallback for the button. Not visible, only required for icon only buttons.
+<button class="my-button-class--icon-only">
+	<!-- accessible text fallback for the button. Not visible, only required for icon only buttons. -->
 	<span class="my-button-class-icon__label">star</span>
 </button>
 ```

--- a/README.md
+++ b/README.md
@@ -238,12 +238,12 @@ Or, using Sass:
 ```scss
 .my-button-class--icon {
  @include oButtons();
- @include oButtonsIconButton(star);
+ @include oButtonsIconButton($icon: star);
 }
 
 .my-button-class--icon-only {
  @include oButtons();
- @include oButtonsIconButton(star);
+ @include oButtonsIconButton($icon: star, $is-icon-only: true);
 }
 ```
 

--- a/demos/src/custom-icon-button.mustache
+++ b/demos/src/custom-icon-button.mustache
@@ -1,23 +1,23 @@
-<button class="demo_custom-icon-button--book">
+<button class="demo__custom-icon-button--book">
 	Book!
 </button>
 
-<button class="demo_custom-icon-button--book--primary">
+<button class="demo__custom-icon-button--book--primary">
 	Book!
 </button>
 
-<button class="demo_custom-icon-button--book--icon-only">
+<button class="demo__custom-icon-button--book--icon-only">
 	<span class="o-buttons-icon__label">
 		Book!
 	</span>
 </button>
 
-<div class='demo_custom-theme--slate'>
-<button class="demo_custom-theme-primary-icon-button--book">
+<div class='demo__custom-theme--slate'>
+<button class="demo__custom-theme-primary-icon-button--book">
 	Book!
 </button>
 
-<button class="demo_custom-theme-secondary-icon-button--book">
+<button class="demo__custom-theme-secondary-icon-button--book">
 	Book!
 </button>
 </div>

--- a/demos/src/custom-icon-button.mustache
+++ b/demos/src/custom-icon-button.mustache
@@ -1,0 +1,13 @@
+<button class="demo_custom-icon-button--book">
+	Book!
+</button>
+
+<button class="demo_custom-icon-button--book--primary">
+	Book!
+</button>
+
+<button class="demo_custom-icon-button--book--icon-only">
+	<span class="o-buttons-icon__label">
+		Book!
+	</span>
+</button>

--- a/demos/src/custom-icon-button.mustache
+++ b/demos/src/custom-icon-button.mustache
@@ -11,3 +11,13 @@
 		Book!
 	</span>
 </button>
+
+<div class='demo_custom-theme--slate'>
+<button class="demo_custom-theme-primary-icon-button--book">
+	Book!
+</button>
+
+<button class="demo_custom-theme-secondary-icon-button--book">
+	Book!
+</button>
+</div>

--- a/demos/src/custom.mustache
+++ b/demos/src/custom.mustache
@@ -1,33 +1,33 @@
 
-<div class="demo_custom-theme demo_custom-theme--slate">
-	<button class="o-buttons demo_custom-theme-button--slate-primary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-primary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-primary" disabled>Custom</button>
+<div class="demo__custom-theme demo__custom-theme--slate">
+	<button class="o-buttons demo__custom-theme-button--slate-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--slate-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--slate-primary" disabled>Custom</button>
 </div>
-<div class="demo_custom-theme demo_custom-theme--slate">
-	<button class="o-buttons demo_custom-theme-button--slate-secondary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-secondary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--slate-secondary" disabled>Custom</button>
-</div>
-
-<div class="demo_custom-theme demo_custom-theme--teal">
-	<button class="o-buttons demo_custom-theme-button--teal-primary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-primary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-primary" disabled>Custom</button>
-</div>
-<div class="demo_custom-theme demo_custom-theme--teal">
-	<button class="o-buttons demo_custom-theme-button--teal-secondary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-secondary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--teal-secondary" disabled>Custom</button>
+<div class="demo__custom-theme demo__custom-theme--slate">
+	<button class="o-buttons demo__custom-theme-button--slate-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--slate-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--slate-secondary" disabled>Custom</button>
 </div>
 
-<div class="demo_custom-theme demo_custom-theme--lemon">
-	<button class="o-buttons demo_custom-theme-button--lemon-primary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-primary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-primary" disabled>Custom</button>
+<div class="demo__custom-theme demo__custom-theme--teal">
+	<button class="o-buttons demo__custom-theme-button--teal-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--teal-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--teal-primary" disabled>Custom</button>
 </div>
-<div class="demo_custom-theme demo_custom-theme--lemon">
-	<button class="o-buttons demo_custom-theme-button--lemon-secondary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-secondary">Custom</button>
-	<button class="o-buttons o-buttons--big demo_custom-theme-button--lemon-secondary" disabled>Custom</button>
+<div class="demo__custom-theme demo__custom-theme--teal">
+	<button class="o-buttons demo__custom-theme-button--teal-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--teal-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--teal-secondary" disabled>Custom</button>
+</div>
+
+<div class="demo__custom-theme demo__custom-theme--lemon">
+	<button class="o-buttons demo__custom-theme-button--lemon-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--lemon-primary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--lemon-primary" disabled>Custom</button>
+</div>
+<div class="demo__custom-theme demo__custom-theme--lemon">
+	<button class="o-buttons demo__custom-theme-button--lemon-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--lemon-secondary">Custom</button>
+	<button class="o-buttons o-buttons--big demo__custom-theme-button--lemon-secondary" disabled>Custom</button>
 </div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -43,65 +43,65 @@ p {
 	margin: 0;
 }
 
-.demo_custom-theme {
+.demo__custom-theme {
 	padding: 1em;
 }
 
-.demo_custom-theme--teal {
+.demo__custom-theme--teal {
 	background-color: oColorsGetPaletteColor(teal-60);
 	padding: 1em;
 }
-.demo_custom-theme--slate {
+.demo__custom-theme--slate {
 	background-color: oColorsGetPaletteColor(slate);
 	padding: 1em;
 }
-.demo_custom-theme--lemon {
+.demo__custom-theme--lemon {
 	background-color: oColorsGetPaletteColor(slate);
 	padding: 1em;
 }
 
-.demo_custom-theme-button--teal-primary {
+.demo__custom-theme-button--teal-primary {
 	@include oButtonsCustomTheme('teal-60', 'white', primary);
 }
-.demo_custom-theme-button--teal-secondary {
+.demo__custom-theme-button--teal-secondary {
 	@include oButtonsCustomTheme('teal-60', 'white', secondary);
 }
-.demo_custom-theme-button--slate-primary {
+.demo__custom-theme-button--slate-primary {
 	@include oButtonsCustomTheme('slate', 'white', primary);
 }
-.demo_custom-theme-button--slate-secondary {
+.demo__custom-theme-button--slate-secondary {
 	@include oButtonsCustomTheme('slate', 'white', secondary);
 }
-.demo_custom-theme-button--lemon-primary {
+.demo__custom-theme-button--lemon-primary {
 	@include oButtonsCustomTheme('slate', 'lemon', primary);
 }
-.demo_custom-theme-button--lemon-secondary {
+.demo__custom-theme-button--lemon-secondary {
 	@include oButtonsCustomTheme('slate', 'lemon', secondary);
 }
 
-.demo_custom-icon-button--book {
+.demo__custom-icon-button--book {
 	@include oButtons('big', 'secondary');
 	@include oButtonsIconButton('book', 'big', 'secondary');
 }
 
-.demo_custom-icon-button--book--primary {
+.demo__custom-icon-button--book--primary {
 	@include oButtons('big', 'primary');
 	@include oButtonsIconButton('book', 'big', 'primary');
 }
 
-.demo_custom-icon-button--book--icon-only {
+.demo__custom-icon-button--book--icon-only {
 	@include oButtons('big', 'primary');
 	@include oButtonsIconButton('book', 'big', 'primary', $is-icon-only: true);
 }
 
-.demo_custom-theme-primary-icon-button--book {
+.demo__custom-theme-primary-icon-button--book {
 	@include oButtons('big');
 	@include oButtonsCustomTheme('slate', 'claret-100', 'primary');
 	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'primary');
 	@include oButtonsIconButton('book', 'big', $custom-theme);
 }
 
-.demo_custom-theme-secondary-icon-button--book {
+.demo__custom-theme-secondary-icon-button--book {
 	@include oButtons(big);
 	@include oButtonsCustomTheme('slate', 'claret-100', secondary);
 	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'secondary');

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -80,23 +80,23 @@ p {
 }
 
 .demo_custom-icon-button--book {
-	@include oButtons('big', 'secondary')
+	@include oButtons('big', 'secondary');
 	@include oButtonsIconButton('book', 'big', 'secondary');
 }
 
 .demo_custom-icon-button--book--primary {
-	@include oButtons('big', 'primary')
+	@include oButtons('big', 'primary');
 	@include oButtonsIconButton('book', 'big', 'primary');
 }
 
 .demo_custom-icon-button--book--icon-only {
-	@include oButtons('big', 'primary')
+	@include oButtons('big', 'primary');
 	@include oButtonsIconButton('book', 'big', 'primary', $is-icon-only: true);
 }
 
 .demo_custom-theme-primary-icon-button--book {
-	@include oButtons(big);
-	@include oButtonsCustomTheme('slate', 'claret-100', primary);
+	@include oButtons('big');
+	@include oButtonsCustomTheme('slate', 'claret-100', 'primary');
 	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'primary');
 	@include oButtonsIconButton('book', 'big', $custom-theme);
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -81,29 +81,29 @@ p {
 
 .demo_custom-icon-button--book {
 	@include oButtons('big', 'secondary')
-	@include oButtonsIconButton('book', 'secondary', 'big');
+	@include oButtonsIconButton('book', 'big', 'secondary');
 }
 
 .demo_custom-icon-button--book--primary {
 	@include oButtons('big', 'primary')
-	@include oButtonsIconButton('book', 'primary', 'big');
+	@include oButtonsIconButton('book', 'big', 'primary');
 }
 
 .demo_custom-icon-button--book--icon-only {
 	@include oButtons('big', 'primary')
-	@include oButtonsIconButton('book', 'primary', 'big', $is-icon-only: true);
+	@include oButtonsIconButton('book', 'big', 'primary', $is-icon-only: true);
 }
 
 .demo_custom-theme-primary-icon-button--book {
 	@include oButtons(big);
 	@include oButtonsCustomTheme('slate', 'claret-100', primary);
 	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'primary');
-	@include oButtonsIconButton('book', $custom-theme, 'big');
+	@include oButtonsIconButton('book', 'big', $custom-theme);
 }
 
 .demo_custom-theme-secondary-icon-button--book {
 	@include oButtons(big);
 	@include oButtonsCustomTheme('slate', 'claret-100', secondary);
 	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'secondary');
-	@include oButtonsIconButton('book', $custom-theme, 'big');
+	@include oButtonsIconButton('book', 'big', $custom-theme);
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -78,3 +78,18 @@ p {
 .demo_custom-theme-button--lemon-secondary {
 	@include oButtonsCustomTheme('slate', 'lemon', secondary);
 }
+
+.demo_custom-icon-button--book {
+	@include oButtons('big', 'secondary')
+	@include oButtonsIconButton('book', 'secondary', 'big');
+}
+
+.demo_custom-icon-button--book--primary {
+	@include oButtons('big', 'primary')
+	@include oButtonsIconButton('book', 'primary', 'big');
+}
+
+.demo_custom-icon-button--book--icon-only {
+	@include oButtons('big', 'primary')
+	@include oButtonsIconButton('book', 'primary', 'big', $is-icon-only: true);
+}

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -93,3 +93,17 @@ p {
 	@include oButtons('big', 'primary')
 	@include oButtonsIconButton('book', 'primary', 'big', $is-icon-only: true);
 }
+
+.demo_custom-theme-primary-icon-button--book {
+	@include oButtons(big);
+	@include oButtonsCustomTheme('slate', 'claret-100', primary);
+	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'primary');
+	@include oButtonsIconButton('book', $custom-theme, 'big');
+}
+
+.demo_custom-theme-secondary-icon-button--book {
+	@include oButtons(big);
+	@include oButtonsCustomTheme('slate', 'claret-100', secondary);
+	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'secondary');
+	@include oButtonsIconButton('book', $custom-theme, 'big');
+}

--- a/designguidelines.md
+++ b/designguidelines.md
@@ -5,6 +5,8 @@
 * __mono__: monochrome
 * __inverse__: for use on dark backgrounds
 * __b2c__: A theme for b2c products eg [http://help.ft.com](http://help.ft.com)
+* __custom theme primary__/__custom theme secondary__: Any color defined in [o-colors](http://registry.origami.ft.com/components/o-colors) can be used to set up custom color buttons
+
 
 and the following sizes:
 
@@ -30,6 +32,6 @@ and have the following states:
 
 * __grouped__: clustering buttons when choosing between options
 * __pagination__: for navigating through pages
-* __icon__: in some cases buttons have an icon instead of text
+* __icon__: in some cases buttons can have an icon instead of or in addition to text
 
 Button width is determined by its content.

--- a/main.scss
+++ b/main.scss
@@ -2,6 +2,7 @@
 @import 'o-colors/main';
 @import 'o-icons/main';
 
+@import 'scss/deprecated';
 @import 'scss/themes';
 @import 'scss/variables';
 @import 'scss/functions';

--- a/main.scss
+++ b/main.scss
@@ -33,7 +33,7 @@
 		@include oButtonsPagination;
 	}
 
-	@include oButtonsIcon;
+	@include _oButtonsGenerateIconButtons;
 
 	.#{$o-buttons-class}-group {
 		@include oButtonsGroup;

--- a/origami.json
+++ b/origami.json
@@ -74,6 +74,12 @@
       "description": "Really big page of demos for all buttons for testing"
     },
     {
+      "name": "custom icon button",
+      "template": "/demos/src/custom-icon-button.mustache",
+      "hidden": true,
+      "description": "Visual tests for the icon buttons mixins"
+    },
+    {
       "name": "pa11y",
       "template": "/demos/src/pa11y.mustache",
       "hidden": true,

--- a/scss/_deprecated.scss
+++ b/scss/_deprecated.scss
@@ -1,0 +1,50 @@
+/// Icon Buttons
+///
+/// Outputs styles for every icon in o-buttons-icons at every theme in o-buttons-themes
+/// @param {String} $buttonClass - class to apply o-buttons styles to
+/// @deprecated This mixin has been deprecated
+@mixin oButtonsIcon($buttonClass: $o-buttons-class) {
+	@warn 'The function oButtonsIcon has been deprecated and will be removed in the next major release of oButtons';
+
+	// Browserhack to only apply these styles for IE7 and up. IE6 will get the
+	// text fallback. Hack documented here: http://browserhacks.com/#hack-da690292d4fddd94dc7bdd50e38b5713
+	html > body .#{$buttonClass}-icon {
+		@include oButtonsBaseStyles;
+
+		@each $theme, $properties in $o-buttons-themes {
+			@each $icon in $o-buttons-icons {
+				@include oButtonsGetButtonForIconAndTheme($icon, $theme);
+			}
+		}
+	}
+}
+
+/// Get Button For Icon and Theme
+///
+/// Outputs background-image property for a given icon/theme at all states set
+/// in that theme's state list
+/// example:
+/// .my-button--left-arrow {
+///	 @include oButtonsGetButtonForIconAndTheme(left-arrow, standout);
+/// }
+///
+/// @param {String} $icon-name, any icon name found in o-ft-icons
+/// @param {String} $theme, any theme name as defined in $o-buttons-themes (standard, standout, etc). Defaults to standard.
+/// @param {String} $button-class, defaults to o-buttons ($o-buttons-class' default value)
+/// @deprecated
+@mixin oButtonsGetButtonForIconAndTheme($icon-name, $theme: secondary, $buttonClass: $o-buttons-class) {
+	@warn 'The mixin oButtonsGetButtonForIconAndTheme has been deprecated. You can use oButtonsIconButton or _oButtonsGenerateIconButtons';
+	&.#{$buttonClass}-icon--#{$icon-name} {
+
+		$theme-selector: null;
+		@if $theme == 'secondary' {
+			$theme-selector: '&';
+		} @else {
+			$theme-selector: '&.#{$buttonClass}--#{$theme}';
+		}
+
+		#{$theme-selector} {
+			@include _oButtonsIconBackgroundImage($icon-name, $theme);
+		}
+	}
+}

--- a/scss/_deprecated.scss
+++ b/scss/_deprecated.scss
@@ -48,3 +48,20 @@
 		}
 	}
 }
+
+/// Base styling for buttons
+///
+/// @param {String} $button-class, defaults to o-buttons ($o-buttons-class' default value)
+/// @deprecated Use oButtonsIconBaseStyles
+@mixin oButtonsBaseStyles($buttonClass: $o-buttons-class) {
+	@warn "oButtonsBaseStyles has been deprecated. Use oButtonsIconBaseStyles instead.";
+	@include oButtonsIconBaseStyles();
+
+	&.#{$o-buttons-class}--big {
+		@include _oButtonsIconSize('big');
+	}
+
+	&.#{$o-buttons-class}-icon--icon-only {
+		@include _oButtonsIconIconOnly;
+	}
+}

--- a/scss/_deprecated.scss
+++ b/scss/_deprecated.scss
@@ -4,7 +4,7 @@
 /// @param {String} $buttonClass - class to apply o-buttons styles to
 /// @deprecated This mixin has been deprecated
 @mixin oButtonsIcon($buttonClass: $o-buttons-class) {
-	@warn 'The function oButtonsIcon has been deprecated and will be removed in the next major release of oButtons';
+	@warn 'The function oButtonsIcon has been deprecated and will be removed in the next major release of oButtons. You can use oButtonsIconButton to get a button for a specific icon, theme and size.';
 
 	// Browserhack to only apply these styles for IE7 and up. IE6 will get the
 	// text fallback. Hack documented here: http://browserhacks.com/#hack-da690292d4fddd94dc7bdd50e38b5713
@@ -33,7 +33,7 @@
 /// @param {String} $button-class, defaults to o-buttons ($o-buttons-class' default value)
 /// @deprecated
 @mixin oButtonsGetButtonForIconAndTheme($icon-name, $theme: secondary, $buttonClass: $o-buttons-class) {
-	@warn 'The mixin oButtonsGetButtonForIconAndTheme has been deprecated. You can use oButtonsIconButton or _oButtonsGenerateIconButtons';
+	@warn 'The mixin oButtonsGetButtonForIconAndTheme has been deprecated. You can use oButtonsIconButton to get a button for a specific icon, theme and size.';
 	&.#{$buttonClass}-icon--#{$icon-name} {
 
 		$theme-selector: null;

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -147,7 +147,7 @@
 /// @param {String} $theme, one of $o-colors-theme
 /// @param {String} $state - One of normal, hover, focus, selected, disabled, pressed
 @mixin _oButtonsGetIconForThemeAndState($icon-name, $theme, $state) {
-	$icon-color : 'mandarin';
+	$icon-color: 'paper';
 	@if type-of($theme) == 'map' {
 		@if map-get($theme, colorizer) == 'secondary' {
 			$icon-color: oColorsGetPaletteColor(map-get($theme, 'accent'));

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -5,9 +5,9 @@
 ///
 /// @param {String} $icon-name, any icon name found in the fticons image set
 /// http://registry.origami.ft.com/components/fticons
-/// @param {String} $theme, any theme name as defined in $o-buttons-themes
-/// (primary, secondary, etc). Custom themes not supported. Defaults to "secondary"
 /// @param {String} $size, "big" or "default"
+/// @param {String | Map} $theme, any theme name as defined in $o-buttons-themes
+/// (primary, secondary, etc) or a Map defining a custom theme.
 /// @param {Boolean} $is-icon-only, if this icon has text accompaniment or is an
 /// icon only.
 ///

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -1,3 +1,27 @@
+/// Icon Button
+///
+/// Outputs the CSS properties for an icon button for the given icon, theme and
+/// size
+///
+/// @param {String} $icon-name, any icon name found in the fticons image set
+/// http://registry.origami.ft.com/components/fticons
+/// @param {String} $theme, any theme name as defined in $o-buttons-themes
+/// (primary, secondary, etc). Custom themes not supported. Defaults to "secondary"
+/// @param {String} $size, "big" or "default"
+/// @param {Boolean} $is-icon-only, if this icon has text accompaniment or is an
+/// icon only.
+///
+@mixin oButtonsIconButton($icon-name, $theme: "secondary", $size: "default", $is-icon-only: false) {
+	@include oButtonsBaseStyles;
+	@include _oButtonsIconSize($size);
+
+	@if $is-icon-only {
+		@include _oButtonsIconIconOnly;
+	}
+
+	@include _oButtonsIcon($icon-name, $theme);
+}
+
 /// Generate concrete classes icon buttons
 ///
 /// Outputs background-image property for all icons in all themes except custom

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -41,34 +41,45 @@
 		}
 
 		#{$theme-selector} {
-			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, normal);
-
-			// http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
-			// http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
-			&[aria-selected=true], // e.g. A selected tab or page number in pagination
-			&[aria-pressed=true] { // e.g. A "follow" button that is pressed
-				@include _oButtonsGetIconForThemeAndState($icon-name, $theme, pressedselected);
-			}
-
-			&[disabled] {
-				@include _oButtonsGetIconForThemeAndState($icon-name, $theme, normal);
-			}
-
-			&:not([disabled]) {
-				&:hover {
-					@include _oButtonsGetIconForThemeAndState($icon-name, $theme, hover);
-				}
-				&:active {
-					@include _oButtonsGetIconForThemeAndState($icon-name, $theme, active);
-				}
-			}
-
-			// Hack to get the active state colour svg to download to prevent FOIC
-			&:after {
-				@include _oButtonsGetIconForThemeAndState($icon-name, $theme, active);
-				content: '';
-			}
+			@include _oButtonsIconBackgroundImage($icon-name, $theme);
 		}
+	}
+}
+
+/// oButtonsIconBackgroundImage
+///
+/// Outputs background image properties for icons in the different button states
+/// for the set theme.
+///
+/// @param {String} $icon-name, any icon name found in o-ft-icons
+/// @param {String} $theme, any theme name as defined in $o-buttons-themes (primary, secondary, etc). Custom themes not supported.
+///
+@mixin _oButtonsIconBackgroundImage($icon-name, $theme) {
+	@include _oButtonsGetIconForThemeAndState($icon-name, $theme, normal);
+	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
+	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
+	&[aria-selected=true], // e.g. A selected tab or page number in pagination
+	&[aria-pressed=true] { // e.g. A "follow" button that is pressed
+		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, pressedselected);
+	}
+
+	&[disabled] {
+		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, normal);
+	}
+
+	&:not([disabled]) {
+		&:hover {
+			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, hover);
+		}
+		&:active {
+			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, active);
+		}
+	}
+
+	// Hack to get the active state colour svg to download to prevent FOIC
+	&:after {
+		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, active);
+		content: '';
 	}
 }
 

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -44,7 +44,7 @@
 	// Browserhack to only apply these styles for IE7 and up. IE6 will get the
 	// text fallback. Hack documented here: http://browserhacks.com/#hack-da690292d4fddd94dc7bdd50e38b5713
 	html > body .#{$o-buttons-class}-icon {
-		@include oButtonsBaseStyles;
+		@include oButtonsIconBaseStyles;
 		@include _oButtonsIconSize('default');
 
 		&.#{$o-buttons-class}--big {

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -19,7 +19,7 @@
 		@include _oButtonsIconIconOnly;
 	}
 
-	@include _oButtonsIcon($icon-name, $theme);
+	@include _oButtonsIconBackgroundImage($icon-name, $theme);
 }
 
 /// Generate concrete classes icon buttons

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -12,7 +12,7 @@
 /// icon only.
 ///
 @mixin oButtonsIconButton($icon-name, $theme: "secondary", $size: "default", $is-icon-only: false) {
-	@include oButtonsBaseStyles;
+	@include oButtonsIconBaseStyles;
 	@include _oButtonsIconSize($size);
 
 	@if $is-icon-only {
@@ -130,20 +130,10 @@
 /// Base styling for buttons
 ///
 /// @param {String} $button-class, defaults to o-buttons ($o-buttons-class' default value)
-@mixin oButtonsBaseStyles($buttonClass: $o-buttons-class) {
+@mixin oButtonsIconBaseStyles($buttonClass: $o-buttons-class) {
 	display: inline-block;
 	background-repeat: no-repeat;
 	background-position: 3px;
-	padding-left: 22px;
-
-	&.o-buttons--big {
-		padding-left: 40px;
-	}
-
-	&.o-buttons-icon--icon-only {
-		padding-left: 0;
-		background-position: 50%;
-	}
 
 	.#{$buttonClass}-icon__label {
 		@include oButtonsIconButtonLabel;

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -1,19 +1,69 @@
-/// Icon Buttons
+/// Generate concrete classes icon buttons
 ///
-/// Outputs styles for every icon in o-buttons-icons at every theme in o-buttons-themes
-/// @param {String} $buttonClass - class to apply o-buttons styles to
-@mixin oButtonsIcon($buttonClass: $o-buttons-class) {
+/// Outputs background-image property for all icons in all themes except custom
+/// themes.
+/// This mixin will iterate through every theme in $o-buttons-themes and every
+/// icon in $o-buttons-icons and create background images for each with the
+/// following class structure:
+/// ```
+/// .o-buttons-icon.o-buttons--primary.o-buttons-icon--warning {...}
+/// .o-buttons-icon.o-buttons--secondary.o-buttons-icon--warning {...}
+/// .o-buttons-icon.o-buttons--inverse.o-buttons-icon--warning {...}
+/// ... and so on...
+/// ```
+/// This mixin also styles for icon buttons where the .o-buttons--big class is present:
+/// ```
+/// .o-buttons-icon.o-buttons-big {...}
+/// ```
+@mixin _oButtonsGenerateIconButtons($o-buttons-class: $o-buttons-class) {
+
 	// Browserhack to only apply these styles for IE7 and up. IE6 will get the
 	// text fallback. Hack documented here: http://browserhacks.com/#hack-da690292d4fddd94dc7bdd50e38b5713
-	html > body .#{$buttonClass}-icon {
+	html > body .#{$o-buttons-class}-icon {
 		@include oButtonsBaseStyles;
+		@include _oButtonsIconSize('default');
+
+		&.#{$o-buttons-class}--big {
+			@include _oButtonsIconSize('big');
+		}
+
+		&.#{$o-buttons-class}-icon--icon-only {
+			@include _oButtonsIconIconOnly;
+		}
 
 		@each $theme, $properties in $o-buttons-themes {
-			@each $icon in $o-buttons-icons {
-				@include oButtonsGetButtonForIconAndTheme($icon, $theme);
+
+			$theme-selector: null;
+			@if $theme == 'secondary' {
+				$theme-selector: '&';
+			} @else {
+				$theme-selector: '&.#{$o-buttons-class}--#{$theme}';
+			}
+
+			#{$theme-selector} {
+
+				@each $icon-name in $o-buttons-icons {
+					&.#{$o-buttons-class}-icon--#{$icon-name} {
+						@include _oButtonsIcon($icon-name, $theme);
+					}
+				}
 			}
 		}
 	}
+}
+
+@mixin _oButtonsIconSize ($size) {
+	@if $size == big {
+		padding-left: 40px;
+	} @else {
+		padding-left: 22px;
+	}
+}
+
+@mixin _oButtonsIconIconOnly {
+	padding-left: 0;
+	background-position: 50%;
+	min-width: 40px;
 }
 
 /// Get Button For Icon and Theme

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -11,7 +11,7 @@
 /// @param {Boolean} $is-icon-only, if this icon has text accompaniment or is an
 /// icon only.
 ///
-@mixin oButtonsIconButton($icon-name, $theme: "secondary", $size: "default", $is-icon-only: false) {
+@mixin oButtonsIconButton($icon-name, $size: "default", $theme: "secondary", $is-icon-only: false) {
 	@include oButtonsIconBaseStyles;
 	@include _oButtonsIconSize($size);
 

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -44,7 +44,7 @@
 
 				@each $icon-name in $o-buttons-icons {
 					&.#{$o-buttons-class}-icon--#{$icon-name} {
-						@include _oButtonsIcon($icon-name, $theme);
+						@include _oButtonsIconBackgroundImage($icon-name, $theme);
 					}
 				}
 			}
@@ -64,36 +64,6 @@
 	padding-left: 0;
 	background-position: 50%;
 	min-width: 40px;
-}
-
-/// Get Button For Icon and Theme
-///
-/// Outputs background-image property for a given icon/theme at all states set
-/// in that theme's state list
-/// example:
-/// .my-button--left-arrow {
-///	 @include oButtonsGetButtonForIconAndTheme(left-arrow, standout);
-/// }
-///
-/// @param {String} $icon-name, any icon name found in o-ft-icons
-/// @param {String} $theme, any theme name as defined in $o-buttons-themes (standard, standout, etc). Defaults to standard.
-/// @param {String} $button-class, defaults to o-buttons ($o-buttons-class' default value)
-///
-@mixin oButtonsGetButtonForIconAndTheme($icon-name, $theme: secondary, $buttonClass: $o-buttons-class) {
-
-	&.#{$buttonClass}-icon--#{$icon-name} {
-
-		$theme-selector: null;
-		@if $theme == 'secondary' {
-			$theme-selector: '&';
-		} @else {
-			$theme-selector: '&.#{$buttonClass}--#{$theme}';
-		}
-
-		#{$theme-selector} {
-			@include _oButtonsIconBackgroundImage($icon-name, $theme);
-		}
-	}
 }
 
 /// oButtonsIconBackgroundImage

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -105,6 +105,7 @@
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination
 	&[aria-pressed=true] { // e.g. A "follow" button that is pressed
 		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, pressedselected);
+
 	}
 
 	&[disabled] {
@@ -146,8 +147,21 @@
 /// @param {String} $theme, one of $o-colors-theme
 /// @param {String} $state - One of normal, hover, focus, selected, disabled, pressed
 @mixin _oButtonsGetIconForThemeAndState($icon-name, $theme, $state) {
-	$state-color: 'o-buttons-#{$theme}-#{$state}';
-	$icon-color: oColorsGetColorFor($state-color, text);
+	$icon-color : 'mandarin';
+	@if type-of($theme) == 'map' {
+		@if map-get($theme, colorizer) == 'secondary' {
+			$icon-color: oColorsGetPaletteColor(map-get($theme, 'accent'));
+		} @else {
+			@if ($state == 'hover') {
+				$icon-color: oColorsGetPaletteColor(map-get($theme, 'accent'));
+			} @else {
+				$icon-color: oColorsGetPaletteColor(map-get($theme, 'background'));
+			}
+		}
+	} @else {
+		$state-color: 'o-buttons-#{$theme}-#{$state}';
+		$icon-color: oColorsGetColorFor($state-color, text);
+	}
 
 	@if $icon-color != null {
 		@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: $icon-color, $iconset-version: 1);


### PR DESCRIPTION
#131 

This PR reworks icon buttons so it is now possible to do:

```css
.demo-button {
  @include oButtons('big', 'primary')
  @include oButtonsIconButton('book', 'big',  'primary');
}
```
and

```
<button class="demo-button">
  Book!
</button>
```

And get an icon button. 

This PR also adds support for custom themes with icons eg: 

```
.demo_custom-theme-secondary-icon-button--book {
	@include oButtons(big);
	@include oButtonsCustomTheme('slate', 'claret-100', secondary);
	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'secondary');
	@include oButtonsIconButton('book', 'big', $custom-theme);
}
```

Finally, this PR makes icon-only icon buttons square.
![screen shot 2017-10-02 at 12 04 38](https://user-images.githubusercontent.com/68009/31074741-f447edb8-a769-11e7-9b43-1a27bbfc0642.png)

** I STILL NEED TO UPDATE THE README **