### PR TITLE
Change mixin signature to accept a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,14 +203,13 @@ Or, using Sass:
 
 oButtonsTheme also accepts a Map, which you can use to create your own themes. The Map can have the following keys:
 - `background`: [String] - the background o-colors colour for the place the button sits on.
-- `accent`: [String] - the accent -colors colour for the button
+- `accent`: [String] - the accent o-colors colour for the button
 - `colorizer`: [String] - an optional parameter for the button style. One of "primary" or "secondary". Defaults to secondary.
 
 To create a `lemon` accented button on a `slate` background:
 
 ```scss
-@include oButtonsCustomTheme(@include oButtonsCustomTheme($theme: (background: 'slate', accent: 'lemon'));
-);
+	@include oButtonsCustomTheme($theme: (background: 'slate', accent: 'lemon'));
 ```
 
 This will output styles for a slate coloured button that has lemon text and border, with a slate/lemon mixed hover state.
@@ -218,7 +217,7 @@ This will output styles for a slate coloured button that has lemon text and bord
 To create a `lemon` _filled_ button on a `slate` background, use the `colorizer` parameter and set to `primary`:
 
 ```scss
-@include oButtonsTheme($theme: (background: 'slate', accent: 'lemon', colorizer: 'secondary'));
+@include oButtonsTheme($theme: (background: 'slate', accent: 'lemon', colorizer: 'primary'));
 ```
 
 This will output styles for a lemon coloured button that has slate text, with a slate/lemon mixed hover state.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ Or, using Sass:
 ```
 
 #### Theme modifiers
+
+There are 5 named themes in oButtons. oButtons also allows developers to create custom themes using o-colors names.
+
 [View demos](http://registry.origami.ft.com/components/o-buttons)
 
 ```html
@@ -198,12 +201,16 @@ Or, using Sass:
 
 #### Custom themes
 
-You can use the `oButtonsCustomTheme` mixin to create custom coloured buttons using the oColors color variables.
+oButtonsTheme also accepts a Map, which you can use to create your own themes. The Map can have the following keys:
+- `background`: [String] - the background o-colors colour for the place the button sits on.
+- `accent`: [String] - the accent -colors colour for the button
+- `colorizer`: [String] - an optional parameter for the button style. One of "primary" or "secondary". Defaults to secondary.
 
-E.g. to create a `lemon` accented button on a `slate` background:
+To create a `lemon` accented button on a `slate` background:
 
 ```scss
-@include oButtonsCustomTheme('slate', 'lemon');
+@include oButtonsCustomTheme(@include oButtonsCustomTheme($theme: (background: 'slate', accent: 'lemon'));
+);
 ```
 
 This will output styles for a slate coloured button that has lemon text and border, with a slate/lemon mixed hover state.
@@ -211,7 +218,7 @@ This will output styles for a slate coloured button that has lemon text and bord
 To create a `lemon` _filled_ button on a `slate` background, use the `colorizer` parameter and set to `primary`:
 
 ```scss
-@include oButtonsCustomTheme('slate', 'lemon', primary);
+@include oButtonsTheme($theme: (background: 'slate', accent: 'lemon', colorizer: 'secondary'));
 ```
 
 This will output styles for a lemon coloured button that has slate text, with a slate/lemon mixed hover state.

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -61,22 +61,24 @@ p {
 }
 
 .demo__custom-theme-button--teal-primary {
-	@include oButtonsCustomTheme('teal-60', 'white', primary);
+	// Test the deprecated mixin pattern still works
+	@include oButtonsCustomTheme('teal-60', 'white', 'primary');
 }
 .demo__custom-theme-button--teal-secondary {
-	@include oButtonsCustomTheme('teal-60', 'white', secondary);
+	// You may just use the oButtonsTheme mixin too
+	@include oButtonsTheme($theme: (background: 'teal-60', accent: 'white', colorizer: 'secondary'));
 }
 .demo__custom-theme-button--slate-primary {
-	@include oButtonsCustomTheme('slate', 'white', primary);
+	@include oButtonsCustomTheme($theme: (background: 'slate', accent: 'white', colorizer: 'primary'));
 }
 .demo__custom-theme-button--slate-secondary {
-	@include oButtonsCustomTheme('slate', 'white', secondary);
+	@include oButtonsCustomTheme($theme: (background: 'slate', accent: 'white', colorizer: 'secondary'));
 }
 .demo__custom-theme-button--lemon-primary {
-	@include oButtonsCustomTheme('slate', 'lemon', primary);
+	@include oButtonsCustomTheme($theme: (background: 'slate', accent: 'lemon', colorizer: 'primary'));
 }
 .demo__custom-theme-button--lemon-secondary {
-	@include oButtonsCustomTheme('slate', 'lemon', secondary);
+	@include oButtonsCustomTheme($theme: (background: 'slate', accent: 'lemon', colorizer: 'secondary'));
 }
 
 .demo__custom-icon-button--book {
@@ -96,14 +98,15 @@ p {
 
 .demo__custom-theme-primary-icon-button--book {
 	@include oButtons('big');
-	@include oButtonsCustomTheme('slate', 'claret-100', 'primary');
 	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'primary');
+	@include oButtonsCustomTheme($theme: $custom-theme);
 	@include oButtonsIconButton('book', 'big', $custom-theme);
 }
 
 .demo__custom-theme-secondary-icon-button--book {
 	@include oButtons(big);
-	@include oButtonsCustomTheme('slate', 'claret-100', secondary);
 	$custom-theme: (background: 'slate', accent: 'claret-100', colorizer: 'secondary');
+
+	@include oButtonsCustomTheme($theme: $custom-theme);
 	@include oButtonsIconButton('book', 'big', $custom-theme);
 }

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -94,8 +94,8 @@
 /// @param {Map} $theme - A map with theme values. $background - The background color of the theme. Must be a color name from o-colors,
 /// $accent - The accent color of the theme. Must be a color name from o-colors, $colorizer - One of primary or secondary (default)
 @mixin oButtonsCustomTheme($background: null, $accent: null, $colorizer: secondary, $theme: ()) {
-	@if ($background or $accent) {
-		@warn "oButtonsCustomTheme: $background and $accent params have now been deprecated and will be removed in the next major release. Pass these values in as a map instead.";
+	@if ($background or $accent or $colorizer) {
+		@warn "oButtonsCustomTheme: $background, $accent and $colorizer params have now been deprecated and will be removed in the next major release. Pass these values in as a map instead.";
 	} @else {
 
 		@if map-has-key($theme, "accent") {

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -54,22 +54,26 @@
 ///
 /// @param {String} $theme
 @mixin oButtonsTheme($theme) {
-	@include _oButtonsPropertiesForState($theme, normal);
+	@if type-of($theme) == 'map' {
+		@include oButtonsCustomTheme($scheme-theme: $theme);
+	} @else {
+		@include _oButtonsPropertiesForState($theme, normal);
 
-	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
-	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
-	&[aria-selected=true], // e.g. A selected tab or page number in pagination
-	&[aria-pressed=true] { // e.g. A "follow" button that is pressed
-		@include _oButtonsPropertiesForState($theme, pressedselected);
-	}
-
-	&:not([disabled]) {
-		&:hover {
-			@include _oButtonsPropertiesForState($theme, hover);
-			text-decoration: none;
+		// http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected
+		// http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed
+		&[aria-selected=true], // e.g. A selected tab or page number in pagination
+		&[aria-pressed=true] { // e.g. A "follow" button that is pressed
+			@include _oButtonsPropertiesForState($theme, pressedselected);
 		}
-		&:active {
-			@include _oButtonsPropertiesForState($theme, active);
+
+		&:not([disabled]) {
+			&:hover {
+				@include _oButtonsPropertiesForState($theme, hover);
+				text-decoration: none;
+			}
+			&:active {
+				@include _oButtonsPropertiesForState($theme, active);
+			}
 		}
 	}
 }
@@ -83,10 +87,34 @@
 /// 	@include oButtonsTheme(black, paper);
 /// }
 ///
-/// @param {String} $background - The background color of the theme. Must be a color name from o-colors
-/// @param {String} $accent - The accent color of the theme. Must be a color name from o-colors
-/// @param {String} $colorizer - One of primary or secondary (default)
-@mixin oButtonsCustomTheme($background, $accent, $colorizer: secondary) {
+///
+/// @deprecated @param {String} $background - The background color of the theme. Must be a color name from o-colors
+/// @deprecated @param {String} $accent - The accent color of the theme. Must be a color name from o-colors
+/// @deprecated @param {String} $colorizer - One of primary or secondary (default)
+/// @param {Map} $theme - A map with theme values. $background - The background color of the theme. Must be a color name from o-colors,
+/// $accent - The accent color of the theme. Must be a color name from o-colors, $colorizer - One of primary or secondary (default)
+@mixin oButtonsCustomTheme($background: null, $accent: null, $colorizer: secondary, $theme: ()) {
+	@if ($background or $accent) {
+		@warn "oButtonsCustomTheme: $background and $accent params have now been deprecated and will be removed in the next major release. Pass these values in as a map instead.";
+	} @else {
+
+		@if map-has-key($theme, "accent") {
+			$accent : map-get($theme, "accent");
+		} @else {
+			@error "oButtonsCustomTheme: Please provide an accent color for the custom button theme";
+		}
+		@if map-has-key($theme, "background") {
+			$background : map-get($theme, "background");
+		} @else {
+			@error "oButtonsCustomTheme: Please provide a background color for the custom button theme";
+		}
+		@if map-has-key($theme, "colorizer") {
+			$colorizer : map-get($theme, "colorizer");
+		} @else {
+			$colorizer: secondary;
+		}
+	}
+
 	$testContrast: oColorsCheckContrast(oColorsGetPaletteColor($background), oColorsGetPaletteColor($accent));
 
 	border-color: oColorsGetPaletteColor($accent);


### PR DESCRIPTION
By passing in a Map or a string to oButtonsTheme() we can allow
devs to use either a named theme, or define their own theme as a Map.

This commit reworks the mixin code a bit to make this possible.