### PR TITLE
Focus styles

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -13,7 +13,7 @@
     "sass": "demos/src/demo.scss",
     "js": "demos/src/demo.js",
     "dependencies": [
-      "o-fonts@^3.0.0"
+      "o-fonts,o-normalise"
     ]
   },
   "demos": [

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -216,17 +216,4 @@
 		cursor: default;
 	}
 
-	&:focus {
-		outline-color: oColorsGetPaletteColor('teal-100');
-		outline-style: solid;
-		outline-width: 2px;
-	}
-
-	// Remove extra padding in Firefox
-	// sass-lint:disable no-vendor-prefixes
-	&::-moz-focus-inner {
-		border: 0;
-		padding: 0;
-	}
-	// sass-lint:enable no-vendor-prefixes
 }

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -184,7 +184,6 @@
 	box-sizing: border-box;
 	vertical-align: middle;
 	margin: 0;
-	outline: 0;
 	border-style: solid;
 	text-align: center;
 	text-decoration: none;


### PR DESCRIPTION
The latest version of o-normalise provides focus styles for things.
You don't have to use o-normalise + o-buttons together but the general premise here is that whatever your focus style is, it should be consistent across all the things, which is not possible when buttons set their own focus style.

This PR removes focus styles for o-buttons.