### PR TITLE
Update registry mixin reference to oButtonsIconButton

### DIFF
--- a/demos/src/icons.mustache
+++ b/demos/src/icons.mustache
@@ -1,5 +1,5 @@
 <h2>Currently supported icons</h2>
-<p>You can add any icon using the <code>oButtonsGetIconButton</code> mixin. If you need an icon button with the build service, please ask the team or raise a PR adding the o-icons icon to the <code>$o-buttons-icons</code> variable.</p>
+<p>You can add any icon using the <code>oButtonsIconButton</code> mixin. If you need an icon button with the build service, please ask the team or raise a PR adding the o-icons icon to the <code>$o-buttons-icons</code> variable.</p>
 	{{#icons}}
 		<button class="o-buttons o-buttons-icon o-buttons-icon--{{name}}">
 			{{text}}


### PR DESCRIPTION
It seems like the registry was referencing a different/old mixin name