### PR TITLE
o-buttons primary inverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,17 @@ o-buttons provides Sass mixins and variables to create buttons.
 
 o-buttons provides styling for:
 
-- **Themes**: `o-buttons--{primary|secondary|inverse|mono|b2c}` or `@include oButtonsTheme($theme);`
+- **Themes**:
+| Theme                   | Selector                               |
+|-------------------------|----------------------------------------|
+| secondary (the default) | .o-buttons                             |
+| inverse                 | .o-buttons--inverse                    |
+| mono                    | .o-buttons--mono                       |
+| primary                 | .o-buttons--primary                    |
+| primary-inverse         | .o-buttons--primary.o-buttons--inverse |
+| b2c                     | .o-buttons--b2b                        |
+
+To apply a theme use one of the above selectors, or if using Bower and silent mode `@include oButtonsTheme($theme);`
 	- **Custom themes**: [Via mixins only] `@include oButtonsCustomTheme($page-background-color, $accent-color);`
 - **Sizes**: `o-buttons--{default|big}` or `@include oButtonsSize($size);`
 - **Grouped buttons**: `o-buttons-group` or `@include oButtonsGroup;`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ o-buttons provides Sass mixins and variables to create buttons.
 
 o-buttons provides styling for:
 
-- **Themes**:
+### Themes
+
 | Theme                   | Selector                               |
 |-------------------------|----------------------------------------|
 | secondary (the default) | .o-buttons                             |
@@ -27,11 +28,19 @@ o-buttons provides styling for:
 | b2c                     | .o-buttons--b2b                        |
 
 To apply a theme use one of the above selectors, or if using Bower and silent mode `@include oButtonsTheme($theme);`
-	- **Custom themes**: [Via mixins only] `@include oButtonsCustomTheme($page-background-color, $accent-color);`
-- **Sizes**: `o-buttons--{default|big}` or `@include oButtonsSize($size);`
-- **Grouped buttons**: `o-buttons-group` or `@include oButtonsGroup;`
-- **Pagination buttons**: `o-buttons-pagination` or `@include oButtonsPagination;`
-- **Icon buttons**: `o-buttons-icon o-buttons-icon--{arrow-left| arrow-right | other supported icon}` or `@include oButtonsIconButton($icon-name, $size, $theme);`
+
+**Custom themes**: `@include oButtonsCustomTheme($theme: (background: $page-background-color, accent: $button-color, colorizer: 'secondary'));`
+
+### Sizes: `o-buttons--{default|big}` or `@include oButtonsSize($size);`
+
+### Grouped buttons
+`.o-buttons-group` or `@include oButtonsGroup;`
+
+### Pagination buttons
+`.o-buttons-pagination` or `@include oButtonsPagination;`
+
+### Icon buttons
+`.o-buttons-icon .o-buttons-icon--{arrow-left| arrow-right | other supported icon}` or `@include oButtonsIconButton($icon-name, $size, $theme);`
 
 You can combine these styles.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ o-buttons provides styling for:
 
 To apply a theme use one of the above selectors, or if using Bower and silent mode `@include oButtonsTheme($theme);`. Using Sass Mixins [custom themes](#custom-themes) are also supported.
 
-### Sizes:
+### Sizes
 `o-buttons--{default|big}` or `@include oButtonsSize($size);`
 
 ### Grouped buttons

--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ o-buttons provides styling for:
 | primary-inverse         | .o-buttons--primary.o-buttons--inverse |
 | b2c                     | .o-buttons--b2b                        |
 
-To apply a theme use one of the above selectors, or if using Bower and silent mode `@include oButtonsTheme($theme);`
+To apply a theme use one of the above selectors, or if using Bower and silent mode `@include oButtonsTheme($theme);`. Using Sass Mixins [custom themes](#custom-themes) are also supported.
 
-**Custom themes**: `@include oButtonsCustomTheme($theme: (background: $page-background-color, accent: $button-color, colorizer: 'secondary'));`
-
-### Sizes: `o-buttons--{default|big}` or `@include oButtonsSize($size);`
+### Sizes:
+`o-buttons--{default|big}` or `@include oButtonsSize($size);`
 
 ### Grouped buttons
 `.o-buttons-group` or `@include oButtonsGroup;`

--- a/demos/src/primary-inverse.mustache
+++ b/demos/src/primary-inverse.mustache
@@ -1,0 +1,3 @@
+<button class="o-buttons o-buttons--primary o-buttons--inverse">Inverse</button>
+<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big">Inverse</button>
+<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big" disabled>Inverse</button>

--- a/designguidelines.md
+++ b/designguidelines.md
@@ -1,21 +1,24 @@
 #### Themes
 
-* __default__/__secondary__: teal outline
-* __primary__: solid teal
-* __mono__: monochrome
+##### Secondary / Default
+The secondary button is the default and usually most used button. This works with:
 * __inverse__: for use on dark backgrounds
-* __b2c__: A theme for b2c products eg [http://help.ft.com](http://help.ft.com)
-* __custom theme primary__/__custom theme secondary__: Any color defined in [o-colors](http://registry.origami.ft.com/components/o-colors) can be used to set up custom color buttons
+* __mono__: monochrome
 
+##### Primary
+The primary button is usually a key call to action. It works with:
+* __inverse__: for use on dark backgrounds
 
-and the following sizes:
+##### Custom Primary/Secondary
+Any color defined in [o-colors](http://registry.origami.ft.com/components/o-colors) can be used to set up custom color buttons for use as a primary or secondary button. See [https://github.com/Financial-Times/o-buttons](the README) for more.
+
+##### B2C
+The b2c button is for some non-editorial products e.g. [http://help.ft.com](http://help.ft.com).
 
 #### Sizes
 
 * __default__: 28px high
 * __big__: 40px high
-
-and have the following states:
 
 #### States
 

--- a/main.scss
+++ b/main.scss
@@ -13,19 +13,35 @@
 @import 'scss/icon';
 
 @if ($o-buttons-is-silent == false) {
-	.#{$o-buttons-class} {
+
+	// Output default/secondary buttons manually.
+	.#{$o-buttons-class},
+	.#{$o-buttons-class}--secondary {
 		@include oButtons;
+	}
+
+	// Output inverse buttons manually.
+	.#{$o-buttons-class}--inverse,
+	.#{$o-buttons-class}--secondary.#{$o-buttons-class}--inverse {
+		@include oButtonsTheme('inverse');
+	}
+
+	.#{$o-buttons-class}--primary.#{$o-buttons-class}--inverse {
+		@include oButtonsTheme('primary-inverse');
+	}
+
+	// Output some themes automatically if not in the manual output map.
+	@each $theme, $properties in $o-buttons-themes {
+		@if not index($_o-buttons-themes-manual-output, $theme) {
+			.#{$o-buttons-class}--#{$theme} {
+				@include oButtonsTheme($theme);
+			}
+		}
 	}
 
 	@each $size, $properties in $o-buttons-sizes {
 		.#{$o-buttons-class}--#{$size} {
 			@include oButtonsSize($size);
-		}
-	}
-
-	@each $theme, $properties in $o-buttons-themes {
-		.#{$o-buttons-class}--#{$theme} {
-			@include oButtonsTheme($theme);
 		}
 	}
 

--- a/origami.json
+++ b/origami.json
@@ -51,7 +51,7 @@
 			"name": "mono",
 			"title": "Monochrome buttons",
 			"template": "/demos/src/mono.mustache",
-			"description": "A monochrome theme for people who need a different theme to those supported by o-buttons (Masterbrand and b2c)"
+			"description": "Secondary/default monochrome theme for people who need a different theme to those supported by o-buttons (Masterbrand and b2c)"
 		},
 		{
 			"name": "B2C",

--- a/origami.json
+++ b/origami.json
@@ -23,22 +23,29 @@
 	"demos": [
 		{
 			"name": "primary",
-			"title": "Masterbrand primary buttons",
+			"title": "Primary button",
 			"template": "/demos/src/primary.mustache",
-			"description": "Primary theme for masterbrand buttons. This is the default theme."
+			"description": "Primary button."
+		},
+		{
+			"name": "primary-inverse",
+			"title": "Primary button (inverse)",
+			"template": "/demos/src/primary-inverse.mustache",
+			"bodyClasses": "inverse",
+			"description": "Primary button which is inversed for use on an alternate background."
 		},
 		{
 			"name": "secondary",
-			"title": "Masterbrand secondary buttons",
+			"title": "Secondary/default button",
 			"template": "/demos/src/secondary.mustache",
-			"description": "Secondary buttons should be used for primary actions."
+			"description": "The secondary button is the default and usually most used button."
 		},
 		{
 			"name": "inverse",
-			"title": "Masterbrand inverse theme",
+			"title": "Secondary/default button (inverse)",
 			"template": "/demos/src/inverse.mustache",
 			"bodyClasses": "inverse",
-			"description": "Inverse buttons for use on dark backgrounds."
+			"description": "Secondary/default button which is inversed for use on an alternate background."
 		},
 		{
 			"name": "mono",

--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -12,6 +12,9 @@
 // Set custom color translucent teal @ 10%
 @include oColorsSetColor('teal-transparent-10', oColorsMix($color: 'teal', $background: 'transparent', $percentage: 10));
 
+@include oColorsSetColor('slate-white-40', oColorsMix($color: 'slate', $background: 'white', $percentage: 40));
+@include oColorsSetColor('slate-white-30', oColorsMix($color: 'slate', $background: 'white', $percentage: 30));
+
 /// scss-lint:disable SpaceAfterComma
 
 // Theme: primary
@@ -104,6 +107,25 @@
 @include oColorsSetUseCase(o-buttons-b2c-disabled, background,        'white');
 @include oColorsSetUseCase(o-buttons-b2c-disabled, text,              'org-b2c-dark');
 
+// Theme: Primary, Inverse
+
+@include oColorsSetUseCase(o-buttons-primary-inverse-normal, text,                'slate');
+@include oColorsSetUseCase(o-buttons-primary-inverse-normal, background,          'white');
+@include oColorsSetUseCase(o-buttons-primary-inverse-normal, border,              'transparent');
+@include oColorsSetUseCase(o-buttons-primary-inverse-hover, text,                 'slate');
+@include oColorsSetUseCase(o-buttons-primary-inverse-hover, background,           'slate-white-40');
+@include oColorsSetUseCase(o-buttons-primary-inverse-hover, border,               'transparent');
+@include oColorsSetUseCase(o-buttons-primary-inverse-focus,  text,              'slate');
+@include oColorsSetUseCase(o-buttons-primary-inverse-focus,  background,        'white');
+@include oColorsSetUseCase(o-buttons-primary-inverse-focus,  border,            'teal-50');
+@include oColorsSetUseCase(o-buttons-primary-inverse-active, text,       'slate');
+@include oColorsSetUseCase(o-buttons-primary-inverse-active, background, 'slate-white-30');
+@include oColorsSetUseCase(o-buttons-primary-inverse-active, border,     'transparent');
+@include oColorsSetUseCase(o-buttons-primary-inverse-pressedselected, text,       'slate');
+@include oColorsSetUseCase(o-buttons-primary-inverse-pressedselected, background, 'slate-white-30');
+@include oColorsSetUseCase(o-buttons-primary-inverse-pressedselected, border,     'transparent');
+@include oColorsSetUseCase(o-buttons-primary-inverse-disabled, background,        'white');
+@include oColorsSetUseCase(o-buttons-primary-inverse-disabled, text,              'slate');
 
 /// Theme: B2C
 ///

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -70,6 +70,11 @@ $o-buttons-themes: (
 	b2c: $o-buttons-themes__b2c
 ) !default;
 
+/// Not all theme selectors match their name.
+/// E.g. 'primary-inverse' is output for '.buttons--primary.o-buttons--inverse'.
+/// These themes should not be output with automatic selectors.
+///
+/// @type Map
 $_o-buttons-themes-manual-output: (
 	'inverse',
 	'primary-inverse',

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -63,11 +63,18 @@ $_o-buttons-border-radius: $o-normalise-border-radius;
 /// @type Map
 $o-buttons-themes: (
 	primary: 'primary',
+	primary-inverse: 'primary-inverse',
 	secondary: 'secondary',
 	inverse: 'inverse',
 	mono: 'mono',
 	b2c: $o-buttons-themes__b2c
 ) !default;
+
+$_o-buttons-themes-manual-output: (
+	'inverse',
+	'primary-inverse',
+	'secondary'
+);
 
 /// List of icons to generate classes for icon buttons.
 /// Build service users will only be able to use these icons, but there is


### PR DESCRIPTION
Adds an inversed primary button as part of https://github.com/Financial-Times/o-buttons/issues/152

<img width="290" alt="screen shot 2018-03-01 at 12 01 08" src="https://user-images.githubusercontent.com/10405691/36843880-4576bd8c-1d48-11e8-965b-251ea27c2805.png">

As theme names don't always match their css selectors I've added a map to prevent them being output automatically.