### PR TITLE
Default colorizer which is set to null.

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -143,7 +143,7 @@
 		@error "Please provide a background color for the custom button theme";
 	}
 
-	@if not map-has-key($theme, "colorizer") {
+	@if map-get($theme, "colorizer") == null {
 		$theme: map-merge($theme, ('colorizer': 'secondary'));
 	}
 


### PR DESCRIPTION
Fixes the deprecated `oButtonsCustomTheme`. If the key isn't set it returns `null`.
http://sass-lang.com/documentation/Sass/Script/Functions.html#map_get-instance_method