### PR TITLE
Remove `:not` pseudo selector 

### DIFF
--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -96,19 +96,20 @@
 ///
 @mixin _oButtonsIconBackgroundImage($icon-name, $theme) {
 	@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'normal');
+	// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
+	// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
+	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
+	&[aria-pressed=true], // e.g. A "follow" button that is pressed.
+	&:not([disabled]):active {
+		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'active');
+	}
+
 	&:not([disabled]) {
 		&:hover {
 			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'hover');
 		}
 		&:focus {
 			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'focus');
-		}
-		// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
-		// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
-		&[aria-selected=true], // e.g. A selected tab or page number in pagination.
-		&[aria-pressed=true], // e.g. A "follow" button that is pressed.
-		&:active {
-			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'active');
 		}
 	}
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -97,6 +97,13 @@
 /// @private
 @mixin _oButtonsStates() {
 	@include _oButtonsColors('default');
+	// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
+	// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
+	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
+	&[aria-pressed=true], // e.g. A "follow" button that is pressed.
+	&:not([disabled]):active {
+		@include _oButtonsColors('active');
+	}
 	&:not([disabled]) {
 		&:hover {
 			@include _oButtonsColors('hover');
@@ -104,13 +111,6 @@
 		}
 		&:focus {
 			@include _oButtonsColors('focus');
-		}
-		// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
-		// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
-		&[aria-selected=true], // e.g. A selected tab or page number in pagination.
-		&[aria-pressed=true], // e.g. A "follow" button that is pressed.
-		&:active {
-			@include _oButtonsColors('active');
 		}
 	}
 }

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -143,7 +143,9 @@
 		@error "Please provide a background color for the custom button theme";
 	}
 
-	@if map-get($theme, "colorizer") == null {
+	// If theme colorizer is not supported default to secondary.
+	$supported-colorizers: ('secondary', 'primary');
+	@if not index($supported-colorizers, map-get($theme, "colorizer")) {
 		$theme: map-merge($theme, ('colorizer': 'secondary'));
 	}
 


### PR DESCRIPTION
- Remove `:not` pseudo selector from button `aria-pressed=true` styles. This isn't necessary and may have caused some specificity issues in dependant projects. https://github.com/Financial-Times/n-myft-ui/blob/2e5075047633b1ecd5537f46cbf6c494d5ac4cb0/myft/ui/myft-buttons/pin-button.scss#L17
- Default to secondary colorizer if an unsupported value is given.