### PR TITLE
add slate to internal 'mono' variant

### DIFF
--- a/scss/_brand.scss
+++ b/scss/_brand.scss
@@ -70,7 +70,18 @@ $_o-buttons-shared-brand-config: (
 ));
 
 @include oBrandDefine('o-buttons', 'internal', (
-    'variables': map-merge($_o-buttons-shared-brand-config, ()),
+    'variables': map-merge($_o-buttons-shared-brand-config, (
+        'mono': (
+              default-color: oColorsGetPaletteColor('slate'),
+              default-background: oColorsGetPaletteColor('transparent'),
+              default-border: oColorsGetPaletteColor('slate'),
+              hover-background: oColorsGetPaletteColor('slate-white-15'),
+              focus-background: oColorsGetPaletteColor('slate-white-15'),
+              active-color: oColorsGetPaletteColor('white'),
+              active-background: oColorsGetPaletteColor('slate')
+            )
+        )
+    ),
     'settings': (
         'primary': true,
         'secondary': true,


### PR DESCRIPTION
It's a small visual change, but it makes a big difference when everything around the button is slate or a version of slate ✌️ 