### PR TITLE
Add primary mono button.

### DIFF
--- a/demos/src/primary-inverse.mustache
+++ b/demos/src/primary-inverse.mustache
@@ -1,4 +1,4 @@
-<button class="o-buttons o-buttons--primary o-buttons--inverse">Inverse</button>
-<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big">Inverse</button>
-<button class="o-buttons o-buttons--primary o-buttons-icon o-buttons-icon--arrow-right o-buttons--inverse o-buttons--big">Inverse</button>
-<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big" disabled>Inverse</button>
+<button class="o-buttons o-buttons--primary o-buttons--inverse">Primary Inverse</button>
+<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big">Primary Inverse</button>
+<button class="o-buttons o-buttons--primary o-buttons-icon o-buttons-icon--arrow-right o-buttons--inverse o-buttons--big">Primary Inverse</button>
+<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big" disabled>Primary Inverse</button>

--- a/demos/src/primary-mono.mustache
+++ b/demos/src/primary-mono.mustache
@@ -1,0 +1,4 @@
+<button class="o-buttons o-buttons--primary o-buttons--mono">Primary Mono</button>
+<button class="o-buttons o-buttons--primary o-buttons--mono o-buttons--big">Primary Mono</button>
+<button class="o-buttons o-buttons--primary o-buttons--mono o-buttons--big o-buttons-icon o-buttons-icon--arrow-right">Primary Mono</button>
+<button class="o-buttons o-buttons--primary o-buttons--mono o-buttons--big" disabled>Primary Mono</button>

--- a/origami.json
+++ b/origami.json
@@ -28,17 +28,17 @@
 			"description": "Primary button."
 		},
 		{
+			"name": "secondary",
+			"title": "Secondary/default button",
+			"template": "/demos/src/secondary.mustache",
+			"description": "The secondary button is the default and usually most used button."
+		},
+		{
 			"name": "primary-inverse",
 			"title": "Primary button (inverse)",
 			"template": "/demos/src/primary-inverse.mustache",
 			"bodyClasses": "inverse",
 			"description": "Primary button which is inversed for use on an alternate background."
-		},
-		{
-			"name": "secondary",
-			"title": "Secondary/default button",
-			"template": "/demos/src/secondary.mustache",
-			"description": "The secondary button is the default and usually most used button."
 		},
 		{
 			"name": "inverse",
@@ -48,10 +48,16 @@
 			"description": "Secondary/default button which is inversed for use on an alternate background."
 		},
 		{
+			"name": "primary-mono",
+			"title": "Primary button (mono)",
+			"template": "/demos/src/primary-mono.mustache",
+			"description": "Primary \"monochrome\" theme."
+		},
+		{
 			"name": "mono",
-			"title": "Monochrome buttons",
+			"title": "Secondary/default button (mono)",
 			"template": "/demos/src/mono.mustache",
-			"description": "Secondary/default monochrome theme for people who need a different theme to those supported by o-buttons (Masterbrand and b2c)"
+			"description": "Secondary/default \"monochrome\" theme."
 		},
 		{
 			"name": "B2C",

--- a/scss/_brand.scss
+++ b/scss/_brand.scss
@@ -29,24 +29,33 @@ $_o-buttons-shared-brand-config: (
         default-color: oColorsGetPaletteColor('white'),
         default-background: oColorsGetPaletteColor('transparent'),
         default-border: oColorsGetPaletteColor('white'),
-        hover-background: oColorsGetPaletteColor('white-slate-20'),
-        focus-background: oColorsGetPaletteColor('white-slate-20'),
+        hover-background: oColorsGetPaletteColor('slate-white-80'),
+        focus-background: oColorsGetPaletteColor('slate-white-80'),
         active-color: oColorsGetPaletteColor('black'),
         active-background: oColorsGetPaletteColor('white')
-    ),
-    'mono': (
-        default-color: oColorsGetPaletteColor('black'),
-        default-background: oColorsGetPaletteColor('transparent'),
-        default-border: oColorsGetPaletteColor('black'),
-        hover-background: oColorsGetPaletteColor('black-10'),
-        focus-background: oColorsGetPaletteColor('black-10'),
-        active-color: oColorsGetPaletteColor('white'),
-        active-background: oColorsGetPaletteColor('black')
     )
 );
 
 @include oBrandDefine('o-buttons', 'master', (
     'variables': map-merge($_o-buttons-shared-brand-config, (
+            ('primary', 'mono'): (
+                default-color: oColorsGetPaletteColor('white'),
+                default-background: oColorsGetPaletteColor('slate'),
+                default-border: oColorsGetPaletteColor('transparent'),
+                hover-background: oColorsGetPaletteColor('slate-paper-70'),
+                focus-background: oColorsGetPaletteColor('slate-paper-70'),
+                active-color: oColorsGetPaletteColor('white'),
+                active-background: oColorsGetPaletteColor('slate-paper-60')
+            ),
+            'mono': (
+                default-color: oColorsGetPaletteColor('black'),
+                default-background: oColorsGetPaletteColor('transparent'),
+                default-border: oColorsGetPaletteColor('black'),
+                hover-background: oColorsGetPaletteColor('black-10'),
+                focus-background: oColorsGetPaletteColor('black-10'),
+                active-color: oColorsGetPaletteColor('white'),
+                active-background: oColorsGetPaletteColor('black')
+            ),
             'b2c': (
                 default-color: oColorsGetPaletteColor('white'),
                 default-background: oColorsGetPaletteColor('org-b2c-dark'),
@@ -71,6 +80,15 @@ $_o-buttons-shared-brand-config: (
 
 @include oBrandDefine('o-buttons', 'internal', (
     'variables': map-merge($_o-buttons-shared-brand-config, (
+        ('primary', 'mono'): (
+            default-color: oColorsGetPaletteColor('white'),
+            default-background: oColorsGetPaletteColor('slate'),
+            default-border: oColorsGetPaletteColor('transparent'),
+            hover-background: oColorsGetPaletteColor('slate-white-70'),
+            focus-background: oColorsGetPaletteColor('slate-white-70'),
+            active-color: oColorsGetPaletteColor('white'),
+            active-background: oColorsGetPaletteColor('slate-white-60')
+        ),
         'mono': (
               default-color: oColorsGetPaletteColor('slate'),
               default-background: oColorsGetPaletteColor('transparent'),

--- a/scss/_brand.scss
+++ b/scss/_brand.scss
@@ -80,23 +80,23 @@ $_o-buttons-shared-brand-config: (
 
 @include oBrandDefine('o-buttons', 'internal', (
     'variables': map-merge($_o-buttons-shared-brand-config, (
-        ('primary', 'mono'): (
-            default-color: oColorsGetPaletteColor('white'),
-            default-background: oColorsGetPaletteColor('slate'),
-            default-border: oColorsGetPaletteColor('transparent'),
-            hover-background: oColorsGetPaletteColor('slate-white-70'),
-            focus-background: oColorsGetPaletteColor('slate-white-70'),
-            active-color: oColorsGetPaletteColor('white'),
-            active-background: oColorsGetPaletteColor('slate-white-60')
-        ),
-        'mono': (
-              default-color: oColorsGetPaletteColor('slate'),
-              default-background: oColorsGetPaletteColor('transparent'),
-              default-border: oColorsGetPaletteColor('slate'),
-              hover-background: oColorsGetPaletteColor('slate-white-15'),
-              focus-background: oColorsGetPaletteColor('slate-white-15'),
-              active-color: oColorsGetPaletteColor('white'),
-              active-background: oColorsGetPaletteColor('slate')
+            ('primary', 'mono'): (
+                default-color: oColorsGetPaletteColor('white'),
+                default-background: oColorsGetPaletteColor('slate'),
+                default-border: oColorsGetPaletteColor('transparent'),
+                hover-background: oColorsGetPaletteColor('slate-white-70'),
+                focus-background: oColorsGetPaletteColor('slate-white-70'),
+                active-color: oColorsGetPaletteColor('white'),
+                active-background: oColorsGetPaletteColor('slate-white-60')
+            ),
+            'mono': (
+                default-color: oColorsGetPaletteColor('slate'),
+                default-background: oColorsGetPaletteColor('transparent'),
+                default-border: oColorsGetPaletteColor('slate'),
+                hover-background: oColorsGetPaletteColor('slate-white-15'),
+                focus-background: oColorsGetPaletteColor('slate-white-15'),
+                active-color: oColorsGetPaletteColor('white'),
+                active-background: oColorsGetPaletteColor('slate')
             )
         )
     ),

--- a/scss/_brand.scss
+++ b/scss/_brand.scss
@@ -38,15 +38,6 @@ $_o-buttons-shared-brand-config: (
 
 @include oBrandDefine('o-buttons', 'master', (
     'variables': map-merge($_o-buttons-shared-brand-config, (
-            ('primary', 'mono'): (
-                default-color: oColorsGetPaletteColor('white'),
-                default-background: oColorsGetPaletteColor('slate'),
-                default-border: oColorsGetPaletteColor('transparent'),
-                hover-background: oColorsGetPaletteColor('slate-paper-70'),
-                focus-background: oColorsGetPaletteColor('slate-paper-70'),
-                active-color: oColorsGetPaletteColor('white'),
-                active-background: oColorsGetPaletteColor('slate-paper-60')
-            ),
             'mono': (
                 default-color: oColorsGetPaletteColor('black'),
                 default-background: oColorsGetPaletteColor('transparent'),
@@ -55,6 +46,15 @@ $_o-buttons-shared-brand-config: (
                 focus-background: oColorsGetPaletteColor('black-10'),
                 active-color: oColorsGetPaletteColor('white'),
                 active-background: oColorsGetPaletteColor('black')
+            ),
+            ('primary', 'mono'): (
+                default-color: oColorsGetPaletteColor('white'),
+                default-background: oColorsGetPaletteColor('slate'),
+                default-border: oColorsGetPaletteColor('transparent'),
+                hover-background: oColorsGetPaletteColor('slate-paper-70'),
+                focus-background: oColorsGetPaletteColor('slate-paper-70'),
+                active-color: oColorsGetPaletteColor('white'),
+                active-background: oColorsGetPaletteColor('slate-paper-60')
             ),
             'b2c': (
                 default-color: oColorsGetPaletteColor('white'),
@@ -80,15 +80,6 @@ $_o-buttons-shared-brand-config: (
 
 @include oBrandDefine('o-buttons', 'internal', (
     'variables': map-merge($_o-buttons-shared-brand-config, (
-            ('primary', 'mono'): (
-                default-color: oColorsGetPaletteColor('white'),
-                default-background: oColorsGetPaletteColor('slate'),
-                default-border: oColorsGetPaletteColor('transparent'),
-                hover-background: oColorsGetPaletteColor('slate-white-70'),
-                focus-background: oColorsGetPaletteColor('slate-white-70'),
-                active-color: oColorsGetPaletteColor('white'),
-                active-background: oColorsGetPaletteColor('slate-white-60')
-            ),
             'mono': (
                 default-color: oColorsGetPaletteColor('slate'),
                 default-background: oColorsGetPaletteColor('transparent'),
@@ -97,6 +88,15 @@ $_o-buttons-shared-brand-config: (
                 focus-background: oColorsGetPaletteColor('slate-white-15'),
                 active-color: oColorsGetPaletteColor('white'),
                 active-background: oColorsGetPaletteColor('slate')
+            ),
+            ('primary', 'mono'): (
+                default-color: oColorsGetPaletteColor('white'),
+                default-background: oColorsGetPaletteColor('slate'),
+                default-border: oColorsGetPaletteColor('transparent'),
+                hover-background: oColorsGetPaletteColor('slate-white-70'),
+                focus-background: oColorsGetPaletteColor('slate-white-70'),
+                active-color: oColorsGetPaletteColor('white'),
+                active-background: oColorsGetPaletteColor('slate-white-60')
             )
         )
     ),

--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -1,6 +1,12 @@
-@include oColorsSetColor('white-slate-20', oColorsMix($color: 'white', $background: 'slate', $percentage: 20));
+@include oColorsSetColor('slate-white-80', oColorsMix($color: 'slate', $background: 'white', $percentage: 80));
 @include oColorsSetColor('slate-white-40', oColorsMix($color: 'slate', $background: 'white', $percentage: 40));
 @include oColorsSetColor('slate-white-30', oColorsMix($color: 'slate', $background: 'white', $percentage: 30));
+@include oColorsSetColor('slate-white-60', oColorsMix($color: 'slate', $background: 'white', $percentage: 60));
+@include oColorsSetColor('slate-white-70', oColorsMix($color: 'slate', $background: 'white', $percentage: 70));
+
+@include oColorsSetColor('slate-paper-60', oColorsMix($color: 'slate', $background: 'paper', $percentage: 60));
+@include oColorsSetColor('slate-paper-70', oColorsMix($color: 'slate', $background: 'paper', $percentage: 70));
+
 @include oColorsSetColor('teal-transparent-10', oColorsMix($color: 'teal', $background: 'transparent', $percentage: 10));
 @include oColorsSetColor('slate-transparent-10', oColorsMix($color: 'slate', $background: 'transparent', $percentage: 10));
 

--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -1,8 +1,8 @@
-@include oColorsSetColor('slate-white-80', oColorsMix($color: 'slate', $background: 'white', $percentage: 80));
 @include oColorsSetColor('slate-white-40', oColorsMix($color: 'slate', $background: 'white', $percentage: 40));
 @include oColorsSetColor('slate-white-30', oColorsMix($color: 'slate', $background: 'white', $percentage: 30));
 @include oColorsSetColor('slate-white-60', oColorsMix($color: 'slate', $background: 'white', $percentage: 60));
 @include oColorsSetColor('slate-white-70', oColorsMix($color: 'slate', $background: 'white', $percentage: 70));
+@include oColorsSetColor('slate-white-80', oColorsMix($color: 'slate', $background: 'white', $percentage: 80));
 
 @include oColorsSetColor('slate-paper-60', oColorsMix($color: 'slate', $background: 'paper', $percentage: 60));
 @include oColorsSetColor('slate-paper-70', oColorsMix($color: 'slate', $background: 'paper', $percentage: 70));

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -63,6 +63,7 @@ $_o-buttons-border-radius: $o-normalise-border-radius;
 $o-buttons-themes: (
 	primary: 'primary',
 	primary-inverse: ('primary', 'inverse'),
+	primary-mono: ('primary', 'mono'),
 	secondary: 'secondary',
 	inverse: 'inverse',
 	mono: 'mono',


### PR DESCRIPTION
- Adds a primary mono button for internal and master brands.
- Adds new palette colours to support the new button variant.
- Removes custom palette colour `white-slate-20` in favour of `slate-white-80`. This technically could be a visually breaking change but is a recent addition and appears unused.

master brand:  primary mono
<img width="554" alt="screen shot 2018-03-28 at 16 23 47" src="https://user-images.githubusercontent.com/10405691/38040735-0aa65440-32a8-11e8-8f65-82af3e046afe.png">

internal brand:  primary mono
<img width="550" alt="screen shot 2018-03-28 at 16 26 42" src="https://user-images.githubusercontent.com/10405691/38040736-0ad25752-32a8-11e8-90c0-32cba190cb48.png">
