### PR TITLE
Use aria-current to identify selected links instead of aria-selected=true

### DIFF
--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -68,7 +68,7 @@
 
 <h3>With anchors</h3>
 <div class="o-buttons__group">
-    <a href="#void" class="o-buttons" aria-selected="true">John</a><!--
+    <a href="#void" class="o-buttons" aria-current="true">John</a><!--
  --><a href="#void" class="o-buttons">Paul</a><!--
  --><a href="#void" class="o-buttons">George</a><!--
  --><a href="#void" class="o-buttons">Ringo</a>
@@ -77,7 +77,7 @@
 <br />
 
 <div class="o-buttons__group">
-    <a href="#void" class="o-buttons o-buttons--big" aria-selected="true">John</a><!--
+    <a href="#void" class="o-buttons o-buttons--big" aria-current="true">John</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">Paul</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">George</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">Ringo</a>
@@ -244,7 +244,7 @@
 
 <h3>With anchors:</h3>
 <div class="o-buttons__pagination">
-	<a href="#void" class="o-buttons" aria-selected="true">1</a>
+	<a href="#void" class="o-buttons" aria-current="true">1</a>
 	<a href="#void" class="o-buttons">2</a>
 	<a href="#void" class="o-buttons">3</a>
 	<span class="faux-inline-block">...</span>

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -1,7 +1,7 @@
 <h2>Default</h2>
 <h3>With anchors</h3>
 <a href="#void" role="button" class="o-buttons">Standard</a>
-<a href="#void" role="button" class="o-buttons" aria-selected="true">Selected</a>
+<a href="#void" role="button" class="o-buttons" aria-current="true">Selected</a>
 <a href="#void" role="button" class="o-buttons" aria-pressed="true">Pressed</a>
 <a href="#void" role="button" class="o-buttons" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -9,7 +9,7 @@
 <br />
 
 <a href="#void" role="button" class="o-buttons o-buttons--big">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--big" aria-selected="true">Selected</a>
+<a href="#void" role="button" class="o-buttons o-buttons--big" aria-current="true">Selected</a>
 <a href="#void" role="button" class="o-buttons o-buttons--big" aria-pressed="true">Pressed</a>
 <a href="#void" role="button" class="o-buttons o-buttons--big" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -18,7 +18,7 @@
 
 <div class="demo-block white">
 	<a href="#void" role="button" class="o-buttons">Standard</a>
-	<a href="#void" role="button" class="o-buttons" aria-selected="true">Selected</a>
+	<a href="#void" role="button" class="o-buttons" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons" aria-pressed="true">Pressed</a>
 	<a href="#void" role="button" class="o-buttons" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -26,7 +26,7 @@
 	<br />
 
 	<a href="#void" role="button" class="o-buttons o-buttons--big">Standard</a>
-	<a href="#void" role="button" class="o-buttons o-buttons--big" aria-selected="true">Selected</a>
+	<a href="#void" role="button" class="o-buttons o-buttons--big" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--big" aria-pressed="true">Pressed</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--big" disabled="disabled" tabindex="-1">Disabled</a>
 </div>
@@ -95,7 +95,7 @@
 <h2>Grouped</h2>
 <h3>With anchors</h3>
 <div class="o-buttons__group">
-    <a href="#void" class="o-buttons" aria-selected="true">John</a><!--
+    <a href="#void" class="o-buttons" aria-current="true">John</a><!--
  --><a href="#void" class="o-buttons">Paul</a><!--
  --><a href="#void" class="o-buttons">George</a><!--
  --><a href="#void" class="o-buttons">Ringo</a>
@@ -104,7 +104,7 @@
 <br />
 
 <div class="o-buttons__group">
-    <a href="#void" class="o-buttons o-buttons--big" aria-selected="true">John</a><!--
+    <a href="#void" class="o-buttons o-buttons--big" aria-current="true">John</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">Paul</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">George</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">Ringo</a>
@@ -115,7 +115,7 @@
 
 <div class="demo-block white">
 	<div class="o-buttons__group">
-	    <a href="#void" class="o-buttons" aria-selected="true">John</a><!--
+	    <a href="#void" class="o-buttons" aria-current="true">John</a><!--
 	 --><a href="#void" class="o-buttons">Paul</a><!--
 	 --><a href="#void" class="o-buttons">George</a><!--
 	 --><a href="#void" class="o-buttons">Ringo</a>
@@ -124,7 +124,7 @@
 	<br />
 
 	<div class="o-buttons__group">
-	    <a href="#void" class="o-buttons o-buttons--big" aria-selected="true">John</a><!--
+	    <a href="#void" class="o-buttons o-buttons--big" aria-current="true">John</a><!--
 	 --><a href="#void" class="o-buttons o-buttons--big">Paul</a><!--
 	 --><a href="#void" class="o-buttons o-buttons--big">George</a><!--
 	 --><a href="#void" class="o-buttons o-buttons--big">Ringo</a>
@@ -177,7 +177,7 @@
 <h2>Standout</h2>
 <h3>With anchors</h3>
 <a href="#void" role="button" class="o-buttons o-buttons--standout">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standout" aria-selected="true">Selected</a>
+<a href="#void" role="button" class="o-buttons o-buttons--standout" aria-current="true">Selected</a>
 <a href="#void" role="button" class="o-buttons o-buttons--standout" aria-pressed="true">Pressed</a>
 <a href="#void" role="button" class="o-buttons o-buttons--standout" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -185,7 +185,7 @@
 <br />
 
 <a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" aria-selected="true">Selected</a>
+<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" aria-current="true">Selected</a>
 <a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" aria-pressed="true">Pressed</a>
 <a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -194,7 +194,7 @@
 
 <div class="demo-block white">
 	<a href="#void" role="button" class="o-buttons o-buttons--standout">Standard</a>
-	<a href="#void" role="button" class="o-buttons o-buttons--standout" aria-selected="true">Selected</a>
+	<a href="#void" role="button" class="o-buttons o-buttons--standout" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--standout" aria-pressed="true">Pressed</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--standout" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -202,7 +202,7 @@
 	<br />
 
 	<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big">Standard</a>
-	<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" aria-selected="true">Selected</a>
+	<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" aria-pressed="true">Pressed</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--standout o-buttons--big" disabled="disabled" tabindex="-1">Disabled</a>
 </div>
@@ -242,7 +242,7 @@
 <h2>Uncolored</h2>
 <h3>With anchors</h3>
 <a href="#void" role="button" class="o-buttons o-buttons--uncolored">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored" aria-selected="true">Selected</a>
+<a href="#void" role="button" class="o-buttons o-buttons--uncolored" aria-current="true">Selected</a>
 <a href="#void" role="button" class="o-buttons o-buttons--uncolored" aria-pressed="true">Pressed</a>
 <a href="#void" role="button" class="o-buttons o-buttons--uncolored" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -250,7 +250,7 @@
 <br />
 
 <a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big">Standard</a>
-<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" aria-selected="true">Selected</a>
+<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" aria-current="true">Selected</a>
 <a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" aria-pressed="true">Pressed</a>
 <a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -259,7 +259,7 @@
 
 <div class="demo-block white">
 	<a href="#void" role="button" class="o-buttons o-buttons--uncolored">Standard</a>
-	<a href="#void" role="button" class="o-buttons o-buttons--uncolored" aria-selected="true">Selected</a>
+	<a href="#void" role="button" class="o-buttons o-buttons--uncolored" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--uncolored" aria-pressed="true">Pressed</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--uncolored" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -267,7 +267,7 @@
 	<br />
 
 	<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big">Standard</a>
-	<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" aria-selected="true">Selected</a>
+	<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" aria-pressed="true">Pressed</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--uncolored o-buttons--big" disabled="disabled" tabindex="-1">Disabled</a>
 </div>
@@ -306,7 +306,7 @@
 <h3>With anchors</h3>
 <div class="demo-block inverse">
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse">Standard</a>
-	<a href="#void" role="button" class="o-buttons o-buttons--inverse" aria-selected="true">Selected</a>
+	<a href="#void" role="button" class="o-buttons o-buttons--inverse" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse" aria-pressed="true">Pressed</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse" disabled="disabled" tabindex="-1">Disabled</a>
 
@@ -314,7 +314,7 @@
 	<br />
 
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse o-buttons--big">Standard</a>
-	<a href="#void" role="button" class="o-buttons o-buttons--inverse o-buttons--big" aria-selected="true">Selected</a>
+	<a href="#void" role="button" class="o-buttons o-buttons--inverse o-buttons--big" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse o-buttons--big" aria-pressed="true">Pressed</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse o-buttons--big" disabled="disabled" tabindex="-1">Disabled</a>
 </div>
@@ -339,7 +339,7 @@
 <h3>With anchors:</h3>
 <div class="o-buttons__pagination">
 	<a href="#void" class="o-buttons o-buttons-icon o-buttons-icon--arrow-left" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></a>
-	<a href="#void" class="o-buttons" aria-selected="true">1</a>
+	<a href="#void" class="o-buttons" aria-current="true">1</a>
 	<a href="#void" class="o-buttons">2</a>
 	<a href="#void" class="o-buttons">3</a>
 	<span class="faux-inline-block">...</span>

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -99,6 +99,7 @@
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
+	&[aria-current], // e.g. A selected tab or page number in pagination (for links only).
 	&[aria-pressed=true], // e.g. A "follow" button that is pressed.
 	&:not([disabled]):active {
 		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'active');

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -100,6 +100,7 @@
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
+	&[aria-current], // e.g. A selected tab or page number in pagination (for links only).
 	&[aria-pressed=true], // e.g. A "follow" button that is pressed.
 	&:not([disabled]):active {
 		@include _oButtonsColors('active');


### PR DESCRIPTION
DAC report tells us that the usage of `aria-selected` attribute in `a` tags is illegal. This PR adds support for using `aria-current` (with any value) instead of `aria-selected=true` for links.