### PR TITLE
Reduce css file size.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   ],
   "dependencies": {
     "o-colors": "^4.2.2",
-    "o-icons": ">=4.4.2 <6",
+    "o-icons": "4.5.0 <6",
     "o-normalise": "^1.2.0",
     "o-brand": "^2.0.1"
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   ],
   "dependencies": {
     "o-colors": "^4.2.2",
-    "o-icons": "4.5.0 <6",
+    "o-icons": ">=4.5.0 <6",
     "o-normalise": "^1.2.0",
     "o-brand": "^2.0.1"
   }

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -160,7 +160,7 @@
 		}
 	}
 	// 3.2. Extend the icon placeholder.
-	@extend %o-buttons-#{$icon-name}-#{$icon-color};
+	@extend %o-buttons-#{$icon-name}-#{$icon-color}; // sass-lint:disable-line extends-before-declarations
 }
 
 /// Icon Button Label

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -41,9 +41,7 @@
 /// ```
 @mixin _oButtonsGenerateIconButtons($o-buttons-class: $o-buttons-class) {
 
-	// Browserhack to only apply these styles for IE7 and up. IE6 will get the
-	// text fallback. Hack documented here: http://browserhacks.com/#hack-da690292d4fddd94dc7bdd50e38b5713
-	html > body .#{$o-buttons-class}-icon {
+	.#{$o-buttons-class}-icon {
 		@include oButtonsIconBaseStyles;
 		@include _oButtonsIconSize('default');
 
@@ -54,18 +52,18 @@
 		&.#{$o-buttons-class}-icon--icon-only {
 			@include _oButtonsIconIconOnly;
 		}
+	}
 
-		@each $key, $theme in $o-buttons-themes {
-			$theme-selector: '&';
-			@if $theme != 'secondary' {
-				$theme-selector: '&.#{_oButtonsGetThemeSelector($theme, $o-buttons-class)}';
-			}
+	@each $key, $theme in $o-buttons-themes {
+		$theme-selector: '&';
+		@if $theme != 'secondary' {
+			$theme-selector: '&.#{_oButtonsGetThemeSelector($theme, $o-buttons-class)}';
+		}
 
-			#{$theme-selector} {
-				@each $icon-name in $o-buttons-icons {
-					&.#{$o-buttons-class}-icon--#{$icon-name} {
-						@include _oButtonsIconBackgroundImage($icon-name, $theme);
-					}
+		#{$theme-selector} {
+			@each $icon-name in $o-buttons-icons {
+				&.#{$o-buttons-class}-icon--#{$icon-name} {
+					@include _oButtonsIconBackgroundImage($icon-name, $theme);
 				}
 			}
 		}
@@ -96,6 +94,14 @@
 ///
 @mixin _oButtonsIconBackgroundImage($icon-name, $theme) {
 	@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'normal');
+	// Add fallback for MS High Contrast mode.
+	// This only needs to be output once, not for every button state.
+	@media screen and (-ms-high-contrast: active) {
+		@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: #ffffff, $iconset-version: 1, $high-contrast-fallback: false);
+	}
+	@media screen and (-ms-high-contrast: black-on-white) {
+		@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: #000000, $iconset-version: 1, $high-contrast-fallback: false);
+	}
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
@@ -112,12 +118,6 @@
 		&:focus {
 			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'focus');
 		}
-	}
-
-	// Hack to get the active state colour svg to download to prevent FOIC
-	&:after {
-		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'active');
-		content: '';
 	}
 }
 
@@ -147,7 +147,17 @@
 		$icon-color: oColorsGetPaletteColor($icon-color);
 	}
 	// 3. Output the icon.
-	@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: $icon-color, $iconset-version: 1);
+	// 3.1. Output the icon placeholder if it has not been output before.
+	@if index($_o-buttons-icon-placeholders, '#{$icon-name}-#{$icon-color}') == null {
+		@at-root {
+			%o-buttons-#{$icon-name}-#{$icon-color} {
+				@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: $icon-color, $iconset-version: 1, $high-contrast-fallback: false);
+			}
+			$_o-buttons-icon-placeholders: append($_o-buttons-icon-placeholders, '#{$icon-name}-#{$icon-color}') !global;
+		}
+	}
+	// 3.2. Extend the icon placeholder.
+	@extend %o-buttons-#{$icon-name}-#{$icon-color};
 }
 
 /// Icon Button Label

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -96,12 +96,15 @@
 	@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'normal');
 	// Add fallback for MS High Contrast mode.
 	// This only needs to be output once, not for every button state.
+	// sass-lint:disable no-vendor-prefixes
 	@media screen and (-ms-high-contrast: active) {
 		@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: #ffffff, $iconset-version: 1, $high-contrast-fallback: false);
 	}
 	@media screen and (-ms-high-contrast: black-on-white) {
 		@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: #000000, $iconset-version: 1, $high-contrast-fallback: false);
 	}
+	// sass-lint:enable no-vendor-prefixes
+
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination.

--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -122,6 +122,12 @@
 			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'focus');
 		}
 	}
+
+	// Hack to get the active state colour svg to download to prevent FOIC
+	&:after {
+		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'active');
+		content: '';
+	}
 }
 
 /// Base styling for buttons

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -78,3 +78,9 @@ $o-buttons-themes: (
 ///
 /// @type List
 $o-buttons-icons: "arrow-left", "arrow-right", "upload", "tick", "plus", "warning", "arrow-down", "arrow-up", "grid", "list" !default;
+
+/// Multiple buttons may output the same icon/icon colour.
+/// SCSS Placeholders are used to only define an icon url once.
+/// @type List
+/// @access Private
+$_o-buttons-icon-placeholders: () !default;


### PR DESCRIPTION
**Aim**
Trim the CSS size of o-buttons without removing default icons or themes, which would require a new major release.

**Why**
As new icons and new button themes have been added the CSS size of  `o-buttons` by default, with silent mode off, has grown rapidly. Handling icons in MS High Contrast mode has also added to a larger CSS bundle. This contributed to the app team hitting local storage limits.

This effects Build Service or Bower users who turn off silent mode. Bower users do not need to include all themes and variations, making `o-buttons` much smaller for these users.

**How**
- Only provide fallback icons for MS High Contrast Mode on the default button. A further fallback for each state is redundant.
- Only output an icon url once using SCSS placeholders.

**Result**

Before:
default ~341kb
gzip ~9kb
brotli ~7kb

After:
default ~86kb
gzip ~5kb
brotli ~4kb