### PR TITLE
Update focus state to override active state.

### DIFF
--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -110,7 +110,7 @@
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
 	&[aria-current], // e.g. A selected tab or page number in pagination (for links only).
 	&[aria-pressed=true], // e.g. A "follow" button that is pressed.
-	&:not([disabled]):active {
+	&:active {
 		@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'active');
 	}
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -102,7 +102,7 @@
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
 	&[aria-current], // e.g. A selected tab or page number in pagination (for links only).
 	&[aria-pressed=true], // e.g. A "follow" button that is pressed.
-	&:not([disabled]):active {
+	&:active {
 		@include _oButtonsColors('active');
 	}
 	&:not([disabled]) {


### PR DESCRIPTION
Before:
![kapture 2018-05-15 at 17 59 10](https://user-images.githubusercontent.com/10405691/40071785-b6d587f4-5869-11e8-988c-5916eaf597c4.gif)
