### PR TITLE
Custom hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,9 @@ Or, using Sass:
 #### Custom themes
 
 oButtonsTheme also accepts a Map, which you can use to create your own themes. The Map can have the following keys:
-- `background`: [String] - the background o-colors colour for the place the button sits on.
-- `accent`: [String] - the accent o-colors colour for the button
+- `background`: [String] - the background `o-colors` color for the place the button sits on.
+- `accent`: [String] - the accent `o-colors` color for the button.
+- `hover`: [String] - an optional parameter for the button hover state. It requires an `o-colors` color. Defaults to a mix of the `background` and `accent` colors.
 - `colorizer`: [String] - an optional parameter for the button style. One of "primary" or "secondary". Defaults to secondary.
 
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -107,7 +107,6 @@
 @mixin _oButtonsColors($state, $theme) {
 	background-color: oButtonsGetColor($state, 'background', $theme);
 	color: oButtonsGetColor($state, 'color', $theme);
-	hover: oButtonsGetColor($state, 'hover', $theme);
 	border-color: oButtonsGetColor($state, 'border', $theme);
 }
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -107,6 +107,7 @@
 @mixin _oButtonsColors($state, $theme) {
 	background-color: oButtonsGetColor($state, 'background', $theme);
 	color: oButtonsGetColor($state, 'color', $theme);
+	hover: oButtonsGetColor($state, 'hover', $theme);
 	border-color: oButtonsGetColor($state, 'border', $theme);
 }
 
@@ -135,14 +136,15 @@
 
 	$colorizer: map-get($theme, 'colorizer');
 	$background: map-get($theme, 'background');
+	$hover: map-get($theme, 'hover');
 	$accent: map-get($theme, 'accent');
 
 	@return (
 		default-color: if($colorizer == 'secondary', oColorsGetPaletteColor($accent), oColorsGetPaletteColor($background)),
 		default-background: if($colorizer == 'secondary', oColorsGetPaletteColor($background), oColorsGetPaletteColor($accent)),
 		default-border: oColorsGetPaletteColor($accent),
-		hover-background: oColorsMix($background, $accent),
-		hover-color: oColorsGetPaletteColor($accent),
+		hover-background: if($hover == null, oColorsMix($background, $accent), oColorsGetPaletteColor($hover)),
+		hover-color: if($hover == null, oColorsGetPaletteColor($accent), oColorsGetTextColor(oColorsGetPaletteColor($hover), 100)),
 		focus-background: if($colorizer == 'secondary', transparent, oColorsGetPaletteColor($accent)),
 		active-color: oColorsGetPaletteColor($background),
 		active-background: oColorsGetPaletteColor($accent)


### PR DESCRIPTION
This PR allows the user to add a custom hover color to a customised button — this has been 'hacked' in some places, and may be needed for future styles of buttons (positive/negative as shown in sketch file, [here](https://github.com/Financial-Times/o-cookie-message/issues/60).