### PR TITLE
Remove icon placeholders (breaks current CSS splitting method)

### DIFF
--- a/scss/_icon.scss
+++ b/scss/_icon.scss
@@ -158,19 +158,7 @@
 	}
 
 	// 3. Output the icon.
-	// 3.1. Output the icon placeholder if it has not been output before.
-	$icon-color-id: str-slice('#{$icon-color}', 2);
-	$icon-placeholder: 'o-buttons-#{$icon-name}-#{$icon-color-id}';
-	@if index($_o-buttons-icon-placeholders, $icon-placeholder) == null {
-		$_o-buttons-icon-placeholders: append($_o-buttons-icon-placeholders, $icon-placeholder) !global;
-		@at-root {
-			%#{$icon-placeholder} {
-				@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: $icon-color, $iconset-version: 1, $high-contrast-fallback: false);
-			}
-		}
-	}
-	// 3.2. Extend the icon placeholder.
-	@extend %#{$icon-placeholder}; // sass-lint:disable-line extends-before-declarations
+	@include oIconsGetIcon($icon-name: $icon-name, $apply-base-styles: false, $apply-width-height: false, $color: $icon-color, $iconset-version: 1, $high-contrast-fallback: false);
 }
 
 /// Icon Button Label

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -79,9 +79,3 @@ $o-buttons-themes: (
 ///
 /// @type List
 $o-buttons-icons: "arrow-left", "arrow-right", "upload", "tick", "plus", "warning", "arrow-down", "arrow-up", "grid", "list" !default;
-
-/// Multiple buttons may output the same icon/icon colour.
-/// SCSS Placeholders are used to only define an icon url once.
-/// @type List
-/// @access Private
-$_o-buttons-icon-placeholders: () !default;


### PR DESCRIPTION
Partially removes [previous changes](https://github.com/Financial-Times/o-buttons/pull/170) to reduce `o-buttons` css bundle size, as placeholders don't play nicely with our [current method of CSS splitting](https://github.com/Financial-Times/next-stream-page/blob/master/client/main.scss#L88). With placeholders the button icons are output only once and split into a separate css file which may or may not be included.

This PR unfortunately increases the default, non-minified, non-compressed size of `o-buttons` from 115kb to 175kb. However, this is still an improvement on before thanks to [only outputting high contrast mode icons](https://github.com/Financial-Times/o-buttons/pull/170/files#diff-45b9f812fa3563c62cf5884a4eaf7497R97) once rather than for every state.