### PR TITLE
Add search and upload icon

### DIFF
--- a/demos/src/icons.json
+++ b/demos/src/icons.json
@@ -13,6 +13,10 @@
 			"text": "Upload"
 		},
 		{
+			"name": "download",
+			"text": "Download"
+		},
+		{
 			"name": "warning",
 			"text": "Danger"
 		},
@@ -43,6 +47,10 @@
 		{
 			"name": "edit",
 			"text": "Edit"
+		},
+		{
+			"name": "search",
+			"text": "Search"
 		}
 	],
 	"themes": [

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -78,4 +78,4 @@ $o-buttons-themes: (
 /// Icon names as used in fticons
 ///
 /// @type List
-$o-buttons-icons: "arrow-left", "arrow-right", "upload", "tick", "plus", "warning", "arrow-down", "arrow-up", "grid", "list", "edit" !default;
+$o-buttons-icons: "arrow-left", "arrow-right", "upload", "tick", "plus", "warning", "arrow-down", "arrow-up", "grid", "list", "edit", "download", "search" !default;


### PR DESCRIPTION
- Upload icon requested by Jame's, in [an issue](https://github.com/Financial-Times/o-buttons/issues/183), to go with the download icon.
- Search icon [requested via Slack](https://financialtimes.slack.com/archives/C02FU5ARJ/p1535645773000100) for use with `o-forms` in a search interface, via the build service.

<img width="111" alt="screen shot 2018-08-31 at 10 27 25" src="https://user-images.githubusercontent.com/10405691/44904941-7ccdb600-ad08-11e8-80b7-b330ca6ae582.png">
<img width="135" alt="screen shot 2018-08-31 at 10 27 29" src="https://user-images.githubusercontent.com/10405691/44904942-7ccdb600-ad08-11e8-987a-a61b8951ac99.png">
