### PR TITLE
Visually hide disabled pagination buttons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Inverse and B2C themes have remained the same.
 Removes deprecated classnames:
 
 ```diff
--.o-buttons__pagination
+-.o-buttons-pagination
 +.o-buttons-pagination
 
 -.o-buttons__group

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Inverse and B2C themes have remained the same.
 Removes deprecated classnames:
 
 ```diff
--.o-buttons-pagination
+-.o-buttons__pagination
 +.o-buttons-pagination
 
 -.o-buttons__group

--- a/demos/src/grouped.mustache
+++ b/demos/src/grouped.mustache
@@ -1,4 +1,4 @@
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons" aria-selected="true">John</button><!--
  --><button class="o-buttons">Paul</button><!--
  --><button class="o-buttons">George</button><!--

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -243,7 +243,7 @@
 <h2>Pagination</h2>
 
 <h3>With anchors:</h3>
-<div class="o-buttons__pagination">
+<div class="o-buttons-pagination">
 	<a href="#void" class="o-buttons" aria-current="true">1</a>
 	<a href="#void" class="o-buttons">2</a>
 	<a href="#void" class="o-buttons">3</a>
@@ -258,7 +258,7 @@
 <br />
 
 <h3>With buttons:</h3>
-<div class="o-buttons__pagination">
+<div class="o-buttons-pagination">
 	<button class="o-buttons" aria-selected="true">1</button>
 	<button class="o-buttons">2</button>
 	<button class="o-buttons">3</button>
@@ -280,7 +280,7 @@
 <br />
 <br />
 
-<div class="o-buttons__pagination">
+<div class="o-buttons-pagination">
 	<button class="o-buttons o-buttons--big" aria-selected="true">1</button>
 	<button class="o-buttons o-buttons--big">2</button>
 	<button class="o-buttons o-buttons--big">3</button>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -67,7 +67,7 @@
 <h2>Grouped</h2>
 
 <h3>With anchors</h3>
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <a href="#void" class="o-buttons" aria-current="true">John</a><!--
  --><a href="#void" class="o-buttons">Paul</a><!--
  --><a href="#void" class="o-buttons">George</a><!--
@@ -76,7 +76,7 @@
 
 <br />
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <a href="#void" class="o-buttons o-buttons--big" aria-current="true">John</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">Paul</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">George</a><!--
@@ -89,7 +89,7 @@
 
 <h3>With buttons</h3>
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons" aria-selected="true">John</button><!--
  --><button class="o-buttons">Paul</button><!--
  --><button class="o-buttons">George</button><!--
@@ -98,7 +98,7 @@
 
 <br />
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons o-buttons--big" aria-selected="true">John</button><!--
  --><button class="o-buttons o-buttons--big">Paul</button><!--
  --><button class="o-buttons o-buttons--big">George</button><!--
@@ -272,7 +272,7 @@
 <br />
 <br />
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>Fewer results</span></button><!--
  --><button class="o-buttons o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>More results</span></button>
 </div>
@@ -294,7 +294,7 @@
 <br />
 <br />
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>Fewer results</span></button><!--
  --><button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>More results</span></button>
 </div>

--- a/demos/src/pagination.mustache
+++ b/demos/src/pagination.mustache
@@ -1,4 +1,4 @@
-<div class="o-buttons__pagination">
+<div class="o-buttons-pagination">
 	<button class="o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>
 	<button class="o-buttons" aria-selected="true">1</button>
 	<button class="o-buttons">2</button>
@@ -13,7 +13,7 @@
 <br />
 <br />
 
-<div class="o-buttons__pagination">
+<div class="o-buttons-pagination">
 	<button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--big o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>
 	<button class="o-buttons o-buttons--big" aria-selected="true">1</button>
 	<button class="o-buttons o-buttons--big">2</button>

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -337,7 +337,7 @@
 
 <h2>Pagination</h2>
 <h3>With anchors:</h3>
-<div class="o-buttons__pagination">
+<div class="o-buttons-pagination">
 	<a href="#void" class="o-buttons o-buttons-icon o-buttons-icon--arrow-left" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></a>
 	<a href="#void" class="o-buttons" aria-current="true">1</a>
 	<a href="#void" class="o-buttons">2</a>
@@ -353,7 +353,7 @@
 <br />
 
 <h3>With buttons:</h3>
-<div class="o-buttons__pagination">
+<div class="o-buttons-pagination">
 	<button class="o-buttons o-buttons-icon o-buttons-icon--arrow-left" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>
 	<button class="o-buttons" aria-selected="true">1</button>
 	<button class="o-buttons">2</button>
@@ -378,7 +378,7 @@
 <br />
 <br />
 
-<div class="o-buttons__pagination">
+<div class="o-buttons-pagination">
 	<button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled="disabled"><span class='o-buttons-icon__label'>Fewer results</span></button>
 	<button class="o-buttons o-buttons--big" aria-selected="true">1</button>
 	<button class="o-buttons o-buttons--big">2</button>

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -94,7 +94,7 @@
 
 <h2>Grouped</h2>
 <h3>With anchors</h3>
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <a href="#void" class="o-buttons" aria-current="true">John</a><!--
  --><a href="#void" class="o-buttons">Paul</a><!--
  --><a href="#void" class="o-buttons">George</a><!--
@@ -103,7 +103,7 @@
 
 <br />
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <a href="#void" class="o-buttons o-buttons--big" aria-current="true">John</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">Paul</a><!--
  --><a href="#void" class="o-buttons o-buttons--big">George</a><!--
@@ -114,7 +114,7 @@
 <br />
 
 <div class="demo-block white">
-	<div class="o-buttons__group">
+	<div class="o-buttons-group">
 	    <a href="#void" class="o-buttons" aria-current="true">John</a><!--
 	 --><a href="#void" class="o-buttons">Paul</a><!--
 	 --><a href="#void" class="o-buttons">George</a><!--
@@ -123,7 +123,7 @@
 
 	<br />
 
-	<div class="o-buttons__group">
+	<div class="o-buttons-group">
 	    <a href="#void" class="o-buttons o-buttons--big" aria-current="true">John</a><!--
 	 --><a href="#void" class="o-buttons o-buttons--big">Paul</a><!--
 	 --><a href="#void" class="o-buttons o-buttons--big">George</a><!--
@@ -137,7 +137,7 @@
 
 
 <h3>With buttons</h3>
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons" aria-selected="true">John</button><!--
  --><button class="o-buttons">Paul</button><!--
  --><button class="o-buttons">George</button><!--
@@ -146,7 +146,7 @@
 
 <br />
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons o-buttons--big" aria-selected="true">John</button><!--
  --><button class="o-buttons o-buttons--big">Paul</button><!--
  --><button class="o-buttons o-buttons--big">George</button><!--
@@ -157,7 +157,7 @@
 <br />
 
 <div class="demo-block white">
-	<div class="o-buttons__group">
+	<div class="o-buttons-group">
 	    <button class="o-buttons" aria-selected="true">John</button><!--
 	 --><button class="o-buttons">Paul</button><!--
 	 --><button class="o-buttons">George</button><!--
@@ -166,7 +166,7 @@
 
 	<br />
 
-	<div class="o-buttons__group">
+	<div class="o-buttons-group">
 	    <button class="o-buttons o-buttons--big" aria-selected="true">John</button><!--
 	 --><button class="o-buttons o-buttons--big">Paul</button><!--
 	 --><button class="o-buttons o-buttons--big">George</button><!--
@@ -368,7 +368,7 @@
 <br />
 <br />
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>Fewer results</span></button><!--
  --><button class="o-buttons o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>More results</span></button>
 </div>
@@ -393,7 +393,7 @@
 <br />
 <br />
 
-<div class="o-buttons__group">
+<div class="o-buttons-group">
     <button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>Fewer results</span></button><!--
  --><button class="o-buttons o-buttons--big o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>More results</span></button>
 </div>

--- a/src/scss/_pagination.scss
+++ b/src/scss/_pagination.scss
@@ -15,6 +15,10 @@
 		padding-right: 5px;
 		min-width: 24px;
 
+		&[disabled] {
+			visibility: hidden;
+		}
+
 		&.#{$buttonClass}--big {
 			padding-left: 9px;
 			padding-right: 9px;


### PR DESCRIPTION
Also correct the demo html. The `o-buttons__pagination` class
was removed back in v5: https://github.com/Financial-Times/o-buttons/pull/116

**Before**:
<img width="726" alt="Screenshot 2019-06-14 at 12 24 02" src="https://user-images.githubusercontent.com/10405691/59506103-55169b80-8e9f-11e9-942b-2b4e76773a2c.png">

**After**: The disabled previous button is visually hidden. The pagination styles
are restored to the demos now they are using the correct pagination class.
<img width="595" alt="Screenshot 2019-06-14 at 12 24 05" src="https://user-images.githubusercontent.com/10405691/59506114-5942b900-8e9f-11e9-84bc-b7ee2c438f07.png">


Also corrects the grouped demo: `o-buttons__group` to `o-buttons-group`.

**Before**:
<img width="282" alt="Screenshot 2019-06-14 at 12 28 22" src="https://user-images.githubusercontent.com/10405691/59506420-0ddcda80-8ea0-11e9-96c4-ada488d76efb.png">

**After**:
<img width="263" alt="Screenshot 2019-06-14 at 12 28 28" src="https://user-images.githubusercontent.com/10405691/59506430-17fed900-8ea0-11e9-9cd5-ecf11f47f0a8.png">
