### PR TITLE
Remove html comment from button group markup.

### DIFF
--- a/demos/src/grouped.mustache
+++ b/demos/src/grouped.mustache
@@ -1,6 +1,6 @@
 <div class="o-buttons-group">
-	<button class="o-buttons o-buttons--secondary" aria-selected="true">John</button><!--
- --><button class="o-buttons o-buttons--secondary">Paul</button><!--
- --><button class="o-buttons o-buttons--secondary">George</button><!--
- --><button class="o-buttons o-buttons--secondary">Ringo</button>
+	<button class="o-buttons o-buttons--secondary" aria-selected="true">John</button>
+	<button class="o-buttons o-buttons--secondary">Paul</button>
+	<button class="o-buttons o-buttons--secondary">George</button>
+	<button class="o-buttons o-buttons--secondary">Ringo</button>
 </div>

--- a/main.scss
+++ b/main.scss
@@ -129,6 +129,8 @@
 	// Group wrapper.
 	@if $groups-enabled {
 		.o-buttons-group {
+			display: flex;
+			flex-wrap: wrap;
 			> .o-buttons {
 				position: relative;
 


### PR DESCRIPTION
Use flexbox so whitespace characters don't impact the layout of
grouped buttons.