### PR TITLE
Fix alignment of large button text when used with an anchor element.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -188,7 +188,6 @@
 /// Styles shared by all buttons of a given size with an icon.
 /// @param {Null|Number} $size
 @mixin _oButtonsIconBaseContent($size: null) {
-	display: inline-block;
 	background-repeat: no-repeat;
 	background-position: 3px;
 	padding-left: _oButtonsGet('icon-padding', $size);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -153,6 +153,9 @@
 	@include oTypographySans($weight: 'semibold');
 	@include _oButtonsSizeContent($size);
 	display: inline-block;
+	// Use flexbox to align text vertically when used with an anchor element.
+	display: inline-flex;
+	align-items: center;
 	box-sizing: border-box;
 	vertical-align: middle;
 	margin: 0;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -154,7 +154,7 @@
 	@include _oButtonsSizeContent($size);
 	display: inline-block;
 	// Use flexbox to align text vertically when used with an anchor element.
-	display: inline-flex;
+	display: inline-flex; // sass-lint:disable-line no-duplicate-properties
 	align-items: center;
 	box-sizing: border-box;
 	vertical-align: middle;

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -105,6 +105,8 @@
 					min-width: 60px;
 					padding: 0 8px;
 					display: inline-block;
+      				display: inline-flex;
+      				align-items: center;
 					box-sizing: border-box;
 					vertical-align: middle;
 					margin: 0;
@@ -167,6 +169,8 @@
 					min-width: 80px;
 					padding: 0 20px;
 					display: inline-block;
+      				display: inline-flex;
+      				align-items: center;
 					box-sizing: border-box;
 					vertical-align: middle;
 					margin: 0;
@@ -185,7 +189,6 @@
 					background-color: #262a33;
 					color: white;
 					border-color: transparent;
-					display: inline-block;
 					background-repeat: no-repeat;
 					background-position: 3px;
 					padding-left: 40px;


### PR DESCRIPTION
before / after
<img width="308" alt="Screenshot 2019-11-12 at 16 08 06" src="https://user-images.githubusercontent.com/10405691/68688513-c3eb4400-0566-11ea-8df1-62fe258fd2cc.png">
