### PR TITLE
Restore inverse theme to the whitelabel brand.

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -34,19 +34,9 @@ p {
 	margin: 0;
 }
 
-.demo__custom-theme {
-	padding: 1em;
-}
-
-.inverse,
-.demo-inverse,
-.demo__custom-theme--slate {
-	background-color: oColorsByName(slate);
-	padding: 1em;
-}
-
-.demo__custom-theme--lemon {
-	background-color: oColorsByName(slate);
+.demo-inverse {
+	$background-color-name: _oButtonsGet('context', $from: 'inverse');
+	background-color: oColorsByName($background-color-name);
 	padding: 1em;
 }
 
@@ -90,4 +80,14 @@ p {
 		$types: ('primary', 'secondary'),
 		$icons: ('book')
 	);
+
+	// Demo containers for the custom buttons
+	.demo__custom-theme {
+		padding: 1em;
+	}
+
+	.demo__custom-theme--lemon,
+	.demo__custom-theme--slate {
+		background-color: oColorsByName('slate');
+	}
 }

--- a/demos/src/test.mustache
+++ b/demos/src/test.mustache
@@ -304,7 +304,7 @@
 </div>
 <h2>Inverse</h2>
 <h3>With anchors</h3>
-<div class="demo-block inverse">
+<div class="demo-block demo-inverse">
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse">Standard</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse" aria-current="true">Selected</a>
 	<a href="#void" role="button" class="o-buttons o-buttons--inverse" aria-pressed="true">Pressed</a>
@@ -320,7 +320,7 @@
 </div>
 
 <h3>With buttons</h3>
-<div class="demo-block inverse">
+<div class="demo-block demo-inverse">
 	<button class="o-buttons o-buttons--inverse">Standard</button>
 	<button class="o-buttons o-buttons--inverse" aria-selected="true">Selected</button>
 	<button class="o-buttons o-buttons--inverse" aria-pressed="true">Pressed</button>

--- a/origami.json
+++ b/origami.json
@@ -43,25 +43,33 @@
 			"name": "primary-inverse",
 			"title": "Primary button (inverse)",
 			"template": "/demos/src/primary-inverse.mustache",
-			"bodyClasses": "inverse",
-			"description": "Primary button which is inversed for use on an alternate background."
+			"bodyClasses": "demo-inverse",
+			"description": "Primary button for use on an alternate, dark background."
 		},
 		{
 			"name": "inverse",
 			"title": "Secondary/default button (inverse)",
 			"template": "/demos/src/inverse.mustache",
-			"bodyClasses": "inverse",
-			"description": "Secondary/default button which is inversed for use on an alternate background."
+			"bodyClasses": "demo-inverse",
+			"description": "Secondary/default button for use on an alternate, dark background."
 		},
 		{
 			"name": "primary-mono",
 			"title": "Primary button (mono)",
+			"brands": [
+				"master",
+				"internal"
+			],
 			"template": "/demos/src/primary-mono.mustache",
 			"description": "Primary \"monochrome\" theme."
 		},
 		{
 			"name": "mono",
 			"title": "Secondary/default button (mono)",
+			"brands": [
+				"master",
+				"internal"
+			],
 			"template": "/demos/src/mono.mustache",
 			"description": "Secondary/default \"monochrome\" theme."
 		},

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -80,11 +80,17 @@ $_o-buttons-shared-brand-config: (
 @if oBrandGetCurrentBrand() == 'whitelabel' {
 	@include oBrandDefine('o-buttons', 'whitelabel', (
 		'variables': map-merge($_o-buttons-shared-brand-config, (
-			'color': 'black'
+			'color': 'black',
+			'inverse': (
+				'color': 'white',
+				'context': 'black'
+			),
 		)),
 		'supports-variants': (
 			'primary',
 			'secondary',
+			'primary-inverse',
+			'secondary-inverse'
 		)
 	));
 }


### PR DESCRIPTION
And fix whitelabel demo builds.
https://github.com/Financial-Times/o-buttons/issues/226