### PR TITLE
Fix an IE11 alignment issue

### DIFF
--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -2,6 +2,7 @@
 <div class="demo-{{.}}">
 	<button class="o-buttons {{#.}}o-buttons--{{.}}{{/.}} o-buttons--primary">Standard</button>
 	<button class="o-buttons {{#.}}o-buttons--{{.}}{{/.}} o-buttons--primary" aria-pressed="true">Pressed</button>
+	<a href="/" class="o-buttons {{#.}}o-buttons--{{.}}{{/.}} o-buttons--primary">Link</a>
 </div>
 {{/themes}}
 
@@ -9,5 +10,6 @@
 <div class="demo-{{.}}">
 	<button class="o-buttons {{#.}}o-buttons--{{.}}{{/.}} o-buttons--secondary">Standard</button>
 	<button class="o-buttons {{#.}}o-buttons--{{.}}{{/.}} o-buttons--secondary" aria-pressed="true">Pressed</button>
+	<a href="/" class="o-buttons {{#.}}o-buttons--{{.}}{{/.}} o-buttons--secondary">Link</a>
 </div>
 {{/themes}}

--- a/demos/src/primary-anchors.mustache
+++ b/demos/src/primary-anchors.mustache
@@ -1,0 +1,5 @@
+<a href="/" class="o-buttons o-buttons--primary">Primary</a>
+<a href="/" class="o-buttons o-buttons--primary o-buttons--big">Primary</a>
+<a href="/" class="o-buttons o-buttons--primary o-buttons-icon o-buttons-icon--arrow-right o-buttons--big">Primary</a>
+<a href="/" class="o-buttons o-buttons--primary o-buttons--big" disabled>Primary</a>
+

--- a/demos/src/secondary-anchors.mustache
+++ b/demos/src/secondary-anchors.mustache
@@ -1,0 +1,4 @@
+<a href="/" class="o-buttons o-buttons--secondary">Secondary</a>
+<a href="/" class="o-buttons o-buttons--secondary o-buttons--big">Secondary</a>
+<a href="/" class="o-buttons o-buttons--secondary o-buttons--big o-buttons-icon o-buttons-icon--arrow-right">Secondary</a>
+<a href="/" class="o-buttons o-buttons--secondary o-buttons--big" disabled>Secondary</a>

--- a/origami.json
+++ b/origami.json
@@ -34,10 +34,24 @@
 			"description": "Primary button."
 		},
 		{
+			"name": "primary-anchors",
+			"title": "Primary anchors",
+			"template": "/demos/src/primary-anchors.mustache",
+			"description": "Primary buttons that are actually anchors.",
+			"hidden": true
+		},
+		{
 			"name": "secondary",
 			"title": "Secondary/default button",
 			"template": "/demos/src/secondary.mustache",
 			"description": "The secondary button is the default and usually most used button."
+		},
+		{
+			"name": "secondary-anchors",
+			"title": "Secondary anchors",
+			"template": "/demos/src/secondary-anchors.mustache",
+			"description": "Secondary buttons that are actually anchors.",
+			"hidden": true
 		},
 		{
 			"name": "primary-inverse",

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -15,14 +15,21 @@ $_o-buttons-shared-brand-config: (
 	'background-size': 21px, // Magic number to reduce poor antialiasing on icons at small sizes
 	'min-height': 28px,
 	'min-width': 60px,
-	'padding': 0 8px,
+	// Sorry for the magic numbers, we need to use vertical padding here because
+	// there is no other way to correctly align button text vertically when the button
+	// element is an anchor. Once we drop IE11 support, we can remove this and use
+	// a display of `inline-flex`.
+	//
+	// The vertical padding magic number is calculated like this:
+	// (min-height - line-height) / 2
+	'padding': 6px 8px,
 	'icon-padding': 22px,
 	'big': (
 		'scale': 0,
 		'background-size': 40px,
 		'min-height': 40px,
 		'min-width': 80px,
-		'padding': 0 20px,
+		'padding': 12px 20px, // See comment above regarding padding magic numbers
 		'icon-padding': 40px
 	),
 );

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -153,10 +153,6 @@
 	@include oTypographySans($weight: 'semibold');
 	@include _oButtonsSizeContent($size);
 	display: inline-block;
-	// Use flexbox to align text vertically when used with an anchor element.
-	display: inline-flex; // sass-lint:disable-line no-duplicate-properties
-	align-items: center;
-	justify-content: center;
 	box-sizing: border-box;
 	vertical-align: middle;
 	margin: 0;

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -103,11 +103,8 @@
 					background-size: 21px;
 					min-height: 28px;
 					min-width: 60px;
-					padding: 0 8px;
+					padding: 6px 8px;
 					display: inline-block;
-      				display: inline-flex;
-					align-items: center;
-					justify-content: center;
 					box-sizing: border-box;
 					vertical-align: middle;
 					margin: 0;
@@ -168,11 +165,8 @@
 					background-size: 40px;
 					min-height: 40px;
 					min-width: 80px;
-					padding: 0 20px;
+					padding: 12px 20px;
 					display: inline-block;
-      				display: inline-flex;
-					align-items: center;
-					justify-content: center;
 					box-sizing: border-box;
 					vertical-align: middle;
 					margin: 0;
@@ -312,7 +306,7 @@
 				background-size: 40px;
 				min-height: 40px;
 				min-width: 80px;
-				padding: 0 20px;
+				padding: 12px 20px;
 
 				.o-typography--loading-sans & {
 					font-size: 13.92px;


### PR DESCRIPTION
Alignment in IE11 was thrown off because of some bad flex support. It
wasn't possible to correctly vertically align text without setting some
vertical padding on the button.

This introduces some magic numbers, which is the way we did this before
the last major version. I'm ignoring the icon size for now, we'll tackle
that separately.

This fixes one part of #232.