### PR TITLE
Fix button sizing

### DIFF
--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -21,7 +21,7 @@ $_o-buttons-shared-brand-config: (
 	// a display of `inline-flex`.
 	//
 	// The vertical padding magic number is calculated like this:
-	// (min-height - line-height) / 2
+	// ((min-height - line-height) / 2) - border-width
 	'padding': 6px 8px,
 	'icon-padding': 22px,
 	'big': (
@@ -29,7 +29,7 @@ $_o-buttons-shared-brand-config: (
 		'background-size': 40px,
 		'min-height': 40px,
 		'min-width': 80px,
-		'padding': 12px 20px, // See comment above regarding padding magic numbers
+		'padding': 11px 20px, // See comment above regarding padding magic numbers
 		'icon-padding': 40px
 	),
 );

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -207,10 +207,12 @@
 /// Styles to size a button.
 /// @param {Null|Number} $size
 @mixin _oButtonsSizeContent($size: null) {
-	@include oTypographySans(
-		$scale: _oButtonsGet('scale', $size),
-		$line-height: 1
-	);
+	@include oTypographySans($scale: _oButtonsGet('scale', $size));
+	$line-height: nth(oTypographyGetScale(
+		$index: _oButtonsGet('scale', $size),
+		$font: oTypographyGetFontFamily('sans')
+	), 1);
+	line-height: #{$line-height}px;
 	background-size: _oButtonsGet('background-size', $size);
 	min-height: _oButtonsGet('min-height', $size);
 	min-width: _oButtonsGet('min-width', $size);

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -99,7 +99,8 @@
 					font-weight: 600;
 					font-family: MetricWeb, sans-serif;
 					font-size: 14px;
-					line-height: 1;
+					line-height: 16px;
+					line-height: 14px;
 					background-size: 21px;
 					min-height: 28px;
 					min-width: 60px;
@@ -161,11 +162,12 @@
 					font-weight: 600;
 					font-family: MetricWeb, sans-serif;
 					font-size: 16px;
-					line-height: 1;
+					line-height: 20px;
+					line-height: 16px;
 					background-size: 40px;
 					min-height: 40px;
 					min-width: 80px;
-					padding: 12px 20px;
+					padding: 11px 20px;
 					display: inline-block;
 					box-sizing: border-box;
 					vertical-align: middle;
@@ -302,11 +304,12 @@
 			@include expect() {
 				font-family: MetricWeb, sans-serif;
 				font-size: 16px;
-				line-height: 1;
+				line-height: 20px;
+				line-height: 16px;
 				background-size: 40px;
 				min-height: 40px;
 				min-width: 80px;
-				padding: 12px 20px;
+				padding: 11px 20px;
 
 				.o-typography--loading-sans & {
 					font-size: 13.92px;


### PR DESCRIPTION
We weren't including border-width in our padding calculations. This is
required, as the button height is border + padding + line-height.