### PR TITLE
Fix the icon demo

### DIFF
--- a/demos/src/icons.json
+++ b/demos/src/icons.json
@@ -54,13 +54,12 @@
 		}
 	],
 	"themes": [
-			{"name": "primary"},
-			{"name": "secondary"},
-			{"name": "mono"},
-			{"name": "inverse"}
-		],
+		{"name": ""},
+		{"name": "mono"},
+		{"name": "inverse"}
+	],
 	"sizes": [
-			{"name": "small"},
-			{"name": "big"}
+		{"name": "small"},
+		{"name": "big"}
 	]
 }

--- a/demos/src/icons.mustache
+++ b/demos/src/icons.mustache
@@ -26,19 +26,27 @@
 {{/icons}}
 
 <h2>Icon buttons with different themes</h2>
-	{{#themes}}
-		<div class='theme-box {{name}}'>
-			<button class="o-buttons o-buttons--secondary o-buttons--{{name}} o-buttons-icon o-buttons-icon--arrow-down">
-				Show
-			</button>
-		</div>
-	{{/themes}}
-	<br>
-	</br>
-	{{#themes}}
-		<div class='theme-box {{name}}'>
-			<button class="o-buttons o-buttons--secondary o-buttons--big o-buttons--{{name}} o-buttons-icon o-buttons-icon--arrow-down">
-				Show
-			</button>
-		</div>
-	{{/themes}}
+
+{{#themes}}
+	<div class='theme-box demo-{{name}}'>
+		<button class="o-buttons o-buttons--primary o-buttons--{{name}} o-buttons-icon o-buttons-icon--arrow-down">
+			Show
+		</button>
+		<button class="o-buttons o-buttons--secondary o-buttons--{{name}} o-buttons-icon o-buttons-icon--arrow-down">
+			Show
+		</button>
+	</div>
+{{/themes}}
+<br/>
+<br/>
+{{#themes}}
+	<div class='theme-box demo-{{name}}'>
+		<button class="o-buttons o-buttons--primary o-buttons--big o-buttons--{{name}} o-buttons-icon o-buttons-icon--arrow-down">
+			Show
+		</button>
+
+		<button class="o-buttons o-buttons--secondary o-buttons--big o-buttons--{{name}} o-buttons-icon o-buttons-icon--arrow-down">
+			Show
+		</button>
+	</div>
+{{/themes}}


### PR DESCRIPTION
The class name for inverted demos changed in v6.0.4, but this demo
wasn't updated. I also noticed that primary buttons weren't displaying
properly as every button has the `o-buttons--secondary` class regardless
of theme. I decided to solve this by showing primary and secondary
buttons of each other theme.

## Demo in v6.0.0

Note the missing primary buttons at the bottom:

<img width="1389" alt="Demo in v6.0.0" src="https://user-images.githubusercontent.com/138944/74423777-b769d680-4e48-11ea-9e89-df0fadcdb949.png">

## Demo in v6.0.4

Note the white-on-paper inverse buttons:

<img width="1391" alt="Demo in v6.0.4" src="https://user-images.githubusercontent.com/138944/74423786-b9339a00-4e48-11ea-9d52-14df7b812414.png">

## Demo on this branch

<img width="1395" alt="Demo on this branch" src="https://user-images.githubusercontent.com/138944/74423790-bafd5d80-4e48-11ea-8539-70514606f2da.png">
