### PR TITLE
Fix button icon sizes in IE11

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -79,10 +79,9 @@
 
 		@each $size in $sizes {
 			.o-buttons--#{$size}.o-buttons-icon {
-				// I can't find any documentation anywhere as to why this is the case,
-				// but IE11 renders the background image at a very small size if you do
-				// not double-up the background size here, declaring a width _and_ height.
-				// Removing the second value will break icons in IE11.
+				// IE11 renders the background image at a very small size if you do not
+				// double-up the background size here, declaring a width _and_ height.
+				// See https://thatemil.com/blog/2015/03/15/sizing-svg-background-images-in-internet-explorer/
 				background-size: _oButtonsGet('background-size', $size) _oButtonsGet('background-size', $size);
 				padding-left: _oButtonsGet('icon-padding', $size);
 			}

--- a/main.scss
+++ b/main.scss
@@ -79,7 +79,11 @@
 
 		@each $size in $sizes {
 			.o-buttons--#{$size}.o-buttons-icon {
-				background-size: _oButtonsGet('background-size', $size);
+				// I can't find any documentation anywhere as to why this is the case,
+				// but IE11 renders the background image at a very small size if you do
+				// not double-up the background size here, declaring a width _and_ height.
+				// Removing the second value will break icons in IE11.
+				background-size: _oButtonsGet('background-size', $size) _oButtonsGet('background-size', $size);
 				padding-left: _oButtonsGet('icon-padding', $size);
 			}
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -213,10 +213,9 @@
 		$font: oTypographyGetFontFamily('sans')
 	), 1);
 	line-height: #{$line-height}px;
-	// I can't find any documentation anywhere as to why this is the case,
-	// but IE11 renders the background image at a very small size if you do
-	// not double-up the background size here, declaring a width _and_ height.
-	// Removing the second value will break icons in IE11.
+	// IE11 renders the background image at a very small size if you do not
+	// double-up the background size here, declaring a width _and_ height.
+	// See https://thatemil.com/blog/2015/03/15/sizing-svg-background-images-in-internet-explorer/
 	background-size: _oButtonsGet('background-size', $size) _oButtonsGet('background-size', $size);
 	min-height: _oButtonsGet('min-height', $size);
 	min-width: _oButtonsGet('min-width', $size);

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -213,7 +213,11 @@
 		$font: oTypographyGetFontFamily('sans')
 	), 1);
 	line-height: #{$line-height}px;
-	background-size: _oButtonsGet('background-size', $size);
+	// I can't find any documentation anywhere as to why this is the case,
+	// but IE11 renders the background image at a very small size if you do
+	// not double-up the background size here, declaring a width _and_ height.
+	// Removing the second value will break icons in IE11.
+	background-size: _oButtonsGet('background-size', $size) _oButtonsGet('background-size', $size);
 	min-height: _oButtonsGet('min-height', $size);
 	min-width: _oButtonsGet('min-width', $size);
 	padding: _oButtonsGet('padding', $size);

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -101,7 +101,7 @@
 					font-size: 14px;
 					line-height: 16px;
 					line-height: 14px;
-					background-size: 21px;
+					background-size: 21px 21px;
 					min-height: 28px;
 					min-width: 60px;
 					padding: 6px 8px;
@@ -164,7 +164,7 @@
 					font-size: 16px;
 					line-height: 20px;
 					line-height: 16px;
-					background-size: 40px;
+					background-size: 40px 40px;
 					min-height: 40px;
 					min-width: 80px;
 					padding: 11px 20px;
@@ -306,7 +306,7 @@
 				font-size: 16px;
 				line-height: 20px;
 				line-height: 16px;
-				background-size: 40px;
+				background-size: 40px 40px;
 				min-height: 40px;
 				min-width: 80px;
 				padding: 11px 20px;


### PR DESCRIPTION
I don't know why this works, but it does. Does anyone have any idea why?
This fixes the second part of #232.

## Before

<img width="620" alt="Small icons before the fix" src="https://user-images.githubusercontent.com/138944/74426468-555fa000-4e4d-11ea-91aa-69860a925970.png">

## After

<img width="619" alt="Correctly-sized icons after the fix" src="https://user-images.githubusercontent.com/138944/74426491-601a3500-4e4d-11ea-9ee5-66e94fbb0837.png">
