### PR TITLE
Enforce no border radius.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -178,6 +178,7 @@
 	-moz-appearance: none;
 	-webkit-appearance: none;
 	// sass-lint:enable no-vendor-prefixes
+	border-radius: 0; // Edge 80 insists on a boarder radius.
 
 	// Same as aria-disabled:
 	// http://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -121,6 +121,7 @@
 					-moz-osx-font-smoothing: grayscale;
 					-moz-appearance: none;
 					-webkit-appearance: none;
+					border-radius: 0;
 				}
 
 				.o-typography--loading-sans .o-buttons {
@@ -184,6 +185,7 @@
 					-moz-osx-font-smoothing: grayscale;
 					-moz-appearance: none;
 					-webkit-appearance: none;
+					border-radius: 0;
 					background-color: #262a33;
 					color: white;
 					border-color: transparent;


### PR DESCRIPTION
Edge 80 adds a 2px border radius to buttons:
https://github.com/Financial-Times/o-buttons/issues/237