### PR TITLE
Make the active state take precedence over the hover state.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -288,11 +288,7 @@
 	}
 
 	// Only output the active icon if it is different to states with less specificity.
-	@if(
-		$active-icon-color != $normal-icon-color or
-		$active-icon-color != $hover-icon-color or
-		$active-icon-color != $focus-icon-color
-	) {
+	@if($active-icon-color != $normal-icon-color or $active-icon-color != $hover-icon-color or $active-icon-color != $focus-icon-color) {
 		// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
 		// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
 		&[aria-selected=true], // e.g. A selected tab or page number in pagination.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -230,32 +230,29 @@
 	background-color: map-get($button-colors-map, 'background');
 	color: map-get($button-colors-map, 'color');
 	border-color: map-get($button-colors-map, 'border');
+
+	&:hover {
+		background-color: map-get($button-colors-map, 'hover-background');
+		color: map-get($button-colors-map, 'hover-color');
+		border-color: map-get($button-colors-map, 'hover-border');
+		text-decoration: none;
+	}
+
+	&:focus {
+		background-color: map-get($button-colors-map, 'focus-background');
+		color: map-get($button-colors-map, 'focus-color');
+		border-color: map-get($button-colors-map, 'focus-border');
+	}
+
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
 	// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
 	&[aria-current], // e.g. A selected tab or page number in pagination (for links only).
 	&[aria-pressed=true], // e.g. A "follow" button that is pressed.
-	&:not([disabled]):active:hover,
-	&:not([disabled])[aria-pressed=true]:hover,
-	&:not([disabled])[aria-selected=true]:hover,
-	&:not([disabled])[aria-current]:hover,
 	&:active {
 		background-color: map-get($button-colors-map, 'active-background');
 		color: map-get($button-colors-map, 'active-color');
 		border-color: map-get($button-colors-map, 'active-border');
-	}
-	&:not([disabled]) {
-		&:hover {
-			background-color: map-get($button-colors-map, 'hover-background');
-			color: map-get($button-colors-map, 'hover-color');
-			border-color: map-get($button-colors-map, 'hover-border');
-			text-decoration: none;
-		}
-		&:focus {
-			background-color: map-get($button-colors-map, 'focus-background');
-			color: map-get($button-colors-map, 'focus-color');
-			border-color: map-get($button-colors-map, 'focus-border');
-		}
 	}
 }
 
@@ -270,34 +267,45 @@
 
 	@include _oButtonsGetIcon($icon, $normal-icon-color);
 
-	// Only output the active icon if it is different to the default icon.
-	@if($normal-icon-color != $active-icon-color) {
+	// Only output the hover icon if it is different to the default icon.
+	@if($hover-icon-color != $normal-icon-color) {
+		&:hover {
+			@include _oButtonsGetIcon($icon, $hover-icon-color);
+		}
+		// Hack to get the hover state colour svg to download to prevent flash
+		// as icon is downloaded on hover
+		&:before {
+			@include _oButtonsGetIcon($icon, $hover-icon-color);
+			content: '';
+		}
+	}
+
+	// Only output the focus icon if it is different to the default or hover icon.
+	@if($focus-icon-color != $normal-icon-color or $focus-icon-color != $hover-icon-color) {
+		&:focus {
+			@include _oButtonsGetIcon($icon, $focus-icon-color);
+		}
+	}
+
+	// Only output the active icon if it is different to states with less specificity.
+	@if(
+		$active-icon-color != $normal-icon-color or
+		$active-icon-color != $hover-icon-color or
+		$active-icon-color != $focus-icon-color
+	) {
 		// https://www.w3.org/TR/wai-aria-1.1/#aria-selected
 		// https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
 		&[aria-selected=true], // e.g. A selected tab or page number in pagination.
 		&[aria-current], // e.g. A selected tab or page number in pagination (for links only).
 		&[aria-pressed=true], // e.g. A "follow" button that is pressed.
-		&:not([disabled]):active:hover,
-		&:not([disabled])[aria-pressed=true]:hover,
-		&:not([disabled])[aria-selected=true]:hover,
-		&:not([disabled])[aria-current]:hover,
 		&:active {
 			@include _oButtonsGetIcon($icon, $active-icon-color);
 		}
-		// Hack to get the active state colour svg to download to prevent FOIC
+		// Hack to get the active state colour svg to download to prevent flash
+		// as icon is downloaded on active
 		&:after {
 			@include _oButtonsGetIcon($icon, $active-icon-color);
 			content: '';
-		}
-	}
-
-	&:not([disabled]) {
-		&:hover {
-			@include _oButtonsGetIcon($icon, $hover-icon-color);
-		}
-
-		&:focus {
-			@include _oButtonsGetIcon($icon, $focus-icon-color);
 		}
 	}
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -235,6 +235,10 @@
 	&[aria-selected=true], // e.g. A selected tab or page number in pagination.
 	&[aria-current], // e.g. A selected tab or page number in pagination (for links only).
 	&[aria-pressed=true], // e.g. A "follow" button that is pressed.
+	&:not([disabled]):active:hover,
+	&:not([disabled])[aria-pressed=true]:hover,
+	&:not([disabled])[aria-selected=true]:hover,
+	&:not([disabled])[aria-current]:hover,
 	&:active {
 		background-color: map-get($button-colors-map, 'active-background');
 		color: map-get($button-colors-map, 'active-color');
@@ -273,6 +277,10 @@
 		&[aria-selected=true], // e.g. A selected tab or page number in pagination.
 		&[aria-current], // e.g. A selected tab or page number in pagination (for links only).
 		&[aria-pressed=true], // e.g. A "follow" button that is pressed.
+		&:not([disabled]):active:hover,
+		&:not([disabled])[aria-pressed=true]:hover,
+		&:not([disabled])[aria-selected=true]:hover,
+		&:not([disabled])[aria-current]:hover,
 		&:active {
 			@include _oButtonsGetIcon($icon, $active-icon-color);
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -292,14 +292,10 @@
 	}
 
 	&:not([disabled]) {
-		// The hover state has higher specificity than only the default state.
-		// So output the hover icon if it is different.
-		$unique-hover-icon: $hover-icon-color != $normal-icon-color;
-		@if($unique-hover-icon) {
-			&:hover {
-				@include _oButtonsGetIcon($icon, $hover-icon-color);
-			}
+		&:hover {
+			@include _oButtonsGetIcon($icon, $hover-icon-color);
 		}
+
 		&:focus {
 			@include _oButtonsGetIcon($icon, $focus-icon-color);
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -292,9 +292,9 @@
 	}
 
 	&:not([disabled]) {
-		// The hover state has higher specificity than the default or active state.
-		// So output the hover icon if it is different to either of these.
-		$unique-hover-icon: ($hover-icon-color != $active-icon-color) or ($hover-icon-color != $normal-icon-color);
+		// The hover state has higher specificity than only the default state.
+		// So output the hover icon if it is different.
+		$unique-hover-icon: $hover-icon-color != $normal-icon-color;
 		@if($unique-hover-icon) {
 			&:hover {
 				@include _oButtonsGetIcon($icon, $hover-icon-color);

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -209,6 +209,10 @@
 				&[aria-selected=true],
 				&[aria-current],
 				&[aria-pressed=true],
+				&:not([disabled]):active:hover,
+				&:not([disabled])[aria-pressed=true]:hover,
+				&:not([disabled])[aria-selected=true]:hover,
+				&:not([disabled])[aria-current]:hover,
 				&:active {
 					background-color: #727071;
 					color: white;
@@ -269,6 +273,10 @@
 				&[aria-selected=true],
 				&[aria-current],
 				&[aria-pressed=true],
+				&:not([disabled]):active:hover,
+				&:not([disabled])[aria-pressed=true]:hover,
+				&:not([disabled])[aria-selected=true]:hover,
+				&:not([disabled])[aria-current]:hover,
 				&:active {
 					background-color: #052f33;
 					color: white;

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -206,38 +206,26 @@
 					cursor: default;
 				}
 
-				&[aria-selected=true],
-				&[aria-current],
-				&[aria-pressed=true],
-				&:not([disabled]):active:hover,
-				&:not([disabled])[aria-pressed=true]:hover,
-				&:not([disabled])[aria-selected=true]:hover,
-				&:not([disabled])[aria-current]:hover,
-				&:active {
-					background-color: #727071;
-					color: white;
-					border-color: transparent;
-				}
-
-				&:not([disabled]):hover {
+				&:hover {
 					background-color: #515257;
 					color: white;
 					border-color: transparent;
 					text-decoration: none;
 				}
 
-				&:not([disabled]):focus {
+				&:focus {
 					background-color: #515257;
 					color: white;
 					border-color: transparent;
 				}
 
-      			&:not([disabled]):hover {
-      				background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrow-left?source=origami-build-tools&tint=%23FFFFFF,%23FFFFFF&format=svg");
-      			}
-
-				&:not([disabled]):focus {
-					background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrow-left?source=origami-build-tools&tint=%23FFFFFF,%23FFFFFF&format=svg");
+				&[aria-selected=true],
+				&[aria-current],
+				&[aria-pressed=true],
+				&:active {
+					background-color: #727071;
+					color: white;
+					border-color: transparent;
 				}
 
 				@media screen and (-ms-high-contrast: active) {
@@ -274,28 +262,24 @@
 					border-color: transparent;
 				}
 
-				&[aria-selected=true],
-				&[aria-current],
-				&[aria-pressed=true],
-				&:not([disabled]):active:hover,
-				&:not([disabled])[aria-pressed=true]:hover,
-				&:not([disabled])[aria-selected=true]:hover,
-				&:not([disabled])[aria-current]:hover,
-				&:active {
-					background-color: #052f33;
-					color: white;
-					border-color: transparent;
-				}
-
-				&:not([disabled]):hover {
+				&:hover {
 					background-color: #095259;
 					color: white;
 					border-color: transparent;
 					text-decoration: none;
 				}
 
-				&:not([disabled]):focus {
+				&:focus {
 					background-color: #095259;
+					color: white;
+					border-color: transparent;
+				}
+
+				&[aria-selected=true],
+				&[aria-current],
+				&[aria-pressed=true],
+				&:active {
+					background-color: #052f33;
 					color: white;
 					border-color: transparent;
 				}

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -232,6 +232,10 @@
 					border-color: transparent;
 				}
 
+      			&:not([disabled]):hover {
+      				background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrow-left?source=origami-build-tools&tint=%23FFFFFF,%23FFFFFF&format=svg");
+      			}
+
 				&:not([disabled]):focus {
 					background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrow-left?source=origami-build-tools&tint=%23FFFFFF,%23FFFFFF&format=svg");
 				}


### PR DESCRIPTION
Our buttons do not give any feedback when clicked. That’s because
the hover state takes precedence over the active state, so the
active state isn’t shown until the cursor is moved away. The lack
of feedback is a pretty bad experience when using buttons to
interact with a page.

For an intimidate improvement, make the active state take precedence
over the hover state so we give that immediate feedback.

The drawback here is an active button then has no hover state.
We need to work with product design on what an active + hover state
looks like for primary and secondary buttons to improve that.

see https://github.com/Financial-Times/o-buttons/issues/247