### PR TITLE
Fix the height of some icon buttons.

### DIFF
--- a/src/scss/_icon.scss
+++ b/src/scss/_icon.scss
@@ -108,7 +108,12 @@
 		// flash on hover
 		&:before {
 			@include _oButtonsGetIconForThemeAndState($icon-name, $theme, 'hover');
-			content: '';
+			// For an unknown reason when button copy has leading whitespace
+			// Safari renders the before pseudo element above the content with
+			// a height of 16px and width 1px, making the button too tall.
+			// If whitespace is included in the pseudo element Safari does not
+			// do this: https://github.com/Financial-Times/o-buttons/issues/250
+			content: ' ';
 		}
 	}
 


### PR DESCRIPTION
For an unknown reason when button copy has leading whitespace
Safari renders the before pseudo element above the content with
a height of 16px and width 1px, making the button too tall.
If whitespace is included in the pseudo element Safari does not
do this: https://github.com/Financial-Times/o-buttons/issues/250