### PR TITLE
Only include button sizes which are valid.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -66,8 +66,10 @@
 
 	// Sizes.
 	@each $size in $sizes {
-		.o-buttons--#{$size} {
-			@include _oButtonsSizeContent($size);
+		@if index($_o-buttons-sizes, $size) {
+			.o-buttons--#{$size} {
+				@include _oButtonsSizeContent($size);
+			}
 		}
 	}
 
@@ -78,12 +80,14 @@
 		}
 
 		@each $size in $sizes {
-			.o-buttons--#{$size}.o-buttons-icon {
-				// IE11 renders the background image at a very small size if you do not
-				// double-up the background size here, declaring a width _and_ height.
-				// See https://thatemil.com/blog/2015/03/15/sizing-svg-background-images-in-internet-explorer/
-				background-size: _oButtonsGet('background-size', $size) _oButtonsGet('background-size', $size);
-				padding-left: _oButtonsGet('icon-padding', $size);
+			@if index($_o-buttons-sizes, $size) {
+				.o-buttons--#{$size}.o-buttons-icon {
+					// IE11 renders the background image at a very small size if you do not
+					// double-up the background size here, declaring a width _and_ height.
+					// See https://thatemil.com/blog/2015/03/15/sizing-svg-background-images-in-internet-explorer/
+					background-size: _oButtonsGet('background-size', $size) _oButtonsGet('background-size', $size);
+					padding-left: _oButtonsGet('icon-padding', $size);
+				}
 			}
 		}
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -88,6 +88,13 @@
 	$size: map-get($opts, 'size');
 	$icon: map-get($opts, 'icon');
 
+	// If a size is given, enforce its an actual button size
+	@if $size and not index($_o-buttons-sizes, $size) {
+		@error '"#{$size}" is not a button size. Allowed sizes include ' +
+			'"#{$_o-buttons-sizes}". Or, do not set the button size to output ' +
+			'the default size.';
+	}
+
 	@if $theme and not $type {
 		$theme-description: if(type-of($theme) == 'string', $theme, 'custom');
 		@warn 'A button theme cannot be output without specifying the button ' +


### PR DESCRIPTION
- `oButtons` only output size modifier classes which are valid.
- `oButtonsContent` error if given size is not valid (this is
technically a breaking change but as the visual output is broken
given an invalid size I think this might be preferable?)