### PR TITLE
Update pagination style and guidance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,21 @@ Wrap buttons with `.o-buttons-group` to group them together:
 
 For a pagination style wrap your buttons in `.o-buttons-pagination`. Most pagination usecases use an anchor `a` tags for links which look like buttons instead of a `button` tag. When using an anchor tag in pagination do not use the `aria-selected` data attribute. Instead use `aria-current="page"` to indicate the current page, this will highlight the button for the current page visually and to screen readers.
 
-In the following example we use links to show pages 1-3 and use icon buttons to indicate more and fewer results:
+The following markup example shows pagination for 20 pages, where the 14th page is the current page. Following the [pagination rules](#pagination-rules) we recommend displaying no more than 7 pages and using the ellipsis element to show hidden results.
 
 ```html
 <div class="o-buttons-pagination">
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
 		<span class='o-buttons-icon__label'>Fewer results</span>
 	</a>
 
-	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">1</a>
-	<a href="#" class="o-buttons o-buttons--secondary">2</a>
-	<a href="#" class="o-buttons o-buttons--secondary">3</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">13</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">14</a>
+	<a href="#" class="o-buttons o-buttons--secondary">15</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">20</a>
 
 	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
 		<span class='o-buttons-icon__label'>More results</span>
@@ -124,7 +128,23 @@ In the following example we use links to show pages 1-3 and use icon buttons to 
 </div>
 ```
 
+#### Pagination Rules
+
+The number of pages to display is not enforced by Origami. However we recommend the following:
+- Show no more than 7 pages at a time. When there are more than 7 pages, hide more pages behind the pagination ellipsis in the following way. Given:
+	- The selected page is below 3 show ellipsis with 3 pages either side.
+	- The selected page is one of the last 2 pages show ellipsis with 3 pages either side.
+	- The 3rd page is selected show 4 pages, the ellipsis, and 2 more pages.
+	- The 3rd from last page is selected show 2 pages, the ellipsis, and 4 more pages.
+	- The selected page is more than 3 from the first of last page show the first page, ellipsis, three pages, ellipsis, and the last page.
+
+For an example see the [pagination demos in the Origami registry](https://registry.origami.ft.com/components/o-buttons@6.0.19#demo-pagination-layout).
+
+#### Pagination Theme
+
 A theme modifier such as `o-buttons--inverse` may be added to the buttons within a pagination block.
+
+#### Pagination Size
 
 ### Disabled
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,28 @@ A theme modifier such as `o-buttons--inverse` may be added to the buttons within
 
 #### Pagination Size
 
+Big buttons may also be used in a pagination style. Add the `o-buttons--big` modifier to each button and `o-buttons-pagination__ellipsis--big` to the ellipsis element.
+
+```html
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">20</a>
+
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+```
+
 ### Disabled
 
 Avoid disabled buttons unless user research shows they improve your interface. Disabled buttons have [poor contrast which makes them difficult to read](#references). They also [do not give feedback to a user why they are disabled](#references).

--- a/demos/src/pagination-size.mustache
+++ b/demos/src/pagination-size.mustache
@@ -1,0 +1,192 @@
+<!-- we recommend showing no more than 7 pages at a time, for more  than 7 pages use the pagination ellipsis -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">3</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">4</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">5</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">6</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">7</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the selected page is below 3, show ellipsis with 3 pages either side -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">2</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the selected page is one of the last 2 pages, show ellipsis with 3 pages either side -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary"  aria-current="page">20</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">19</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the 3rd page is selected, show 4 pages, the ellipsis, and 2 more pages -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">3</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">4</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the 3rd from last page is selected, show 2 pages, the ellipsis, and 4 more pages -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">2</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">17</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">18</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the selected page is more than 3 from the first of last page -->
+<!-- show the first page, ellipsis, three pages, ellipsis, and the last page -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">1</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">13</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">14</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">15</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- note that a large number of pages (3 or more digits) will effect the size and alignment of pagination -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">2</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">198</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">199</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">200</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">1</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">100</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary" aria-current="page">101</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">102</a>
+	<span class="o-buttons-pagination__ellipsis o-buttons-pagination__ellipsis--big">...</span>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary">200</a>
+	<a href="#" class="o-buttons o-buttons--big o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>

--- a/demos/src/pagination.mustache
+++ b/demos/src/pagination.mustache
@@ -1,25 +1,192 @@
+<!-- we recommend showing no more than 7 pages at a time, for more  than 7 pages use the pagination ellipsis -->
+
 <div class="o-buttons-pagination">
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled><span class='o-buttons-icon__label'>Fewer results</span></a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
 	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">1</a>
 	<a href="#" class="o-buttons o-buttons--secondary">2</a>
 	<a href="#" class="o-buttons o-buttons--secondary">3</a>
-	<span>...</span>
-	<a href="#" class="o-buttons o-buttons--secondary">25</a>
-	<a href="#" class="o-buttons o-buttons--secondary">26</a>
-	<a href="#" class="o-buttons o-buttons--secondary">27</a>
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>More results</span></a>
+	<a href="#" class="o-buttons o-buttons--secondary">4</a>
+	<a href="#" class="o-buttons o-buttons--secondary">5</a>
+	<a href="#" class="o-buttons o-buttons--secondary">6</a>
+	<a href="#" class="o-buttons o-buttons--secondary">7</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
 </div>
 
-<br />
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the selected page is below 3, show ellipsis with 3 pages either side -->
 
 <div class="o-buttons-pagination">
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons--big o-buttons-icon o-buttons-icon--big o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled><span class='o-buttons-icon__label'>Fewer results</span></a>
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons--big" aria-current="page">1</a>
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons--big">2</a>
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons--big">3</a>
-	<span>...</span>
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons--big">25</a>
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons--big">26</a>
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons--big">27</a>
-	<a href="#" class="o-buttons o-buttons--secondary o-buttons--big o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only"><span class='o-buttons-icon__label'>More results</span></a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">1</a>
+	<a href="#" class="o-buttons o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">2</a>
+	<a href="#" class="o-buttons o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the selected page is one of the last 2 pages, show ellipsis with 3 pages either side -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--secondary"  aria-current="page">20</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only" disabled>
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">18</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">19</a>
+	<a href="#" class="o-buttons o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the 3rd page is selected, show 4 pages, the ellipsis, and 2 more pages -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--secondary">2</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">3</a>
+	<a href="#" class="o-buttons o-buttons--secondary">4</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the 3rd from last page is selected, show 2 pages, the ellipsis, and 4 more pages -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--secondary">2</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">17</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">18</a>
+	<a href="#" class="o-buttons o-buttons--secondary">19</a>
+	<a href="#" class="o-buttons o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- when the there are more than 7 pages, and the selected page is more than 3 from the first of last page -->
+<!-- show the first page, ellipsis, three pages, ellipsis, and the last page -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">13</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">14</a>
+	<a href="#" class="o-buttons o-buttons--secondary">15</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">20</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<!-- note that a large number of pages (3 or more digits) will effect the size and alignment of pagination -->
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">2</a>
+	<a href="#" class="o-buttons o-buttons--secondary">3</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">198</a>
+	<a href="#" class="o-buttons o-buttons--secondary">199</a>
+	<a href="#" class="o-buttons o-buttons--secondary">200</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
+</div>
+
+<br class="demo-break">
+
+<div class="o-buttons-pagination">
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-left o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>Fewer results</span>
+	</a>
+	<a href="#" class="o-buttons o-buttons--secondary">1</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">100</a>
+	<a href="#" class="o-buttons o-buttons--secondary" aria-current="page">101</a>
+	<a href="#" class="o-buttons o-buttons--secondary">102</a>
+	<span class="o-buttons-pagination__ellipsis">...</span>
+	<a href="#" class="o-buttons o-buttons--secondary">200</a>
+	<a href="#" class="o-buttons o-buttons--secondary o-buttons-icon o-buttons-icon--arrow-right o-buttons-icon--icon-only">
+		<span class='o-buttons-icon__label'>More results</span>
+	</a>
 </div>

--- a/main.scss
+++ b/main.scss
@@ -116,20 +116,39 @@
 	// Pagination wrapper.
 	@if $pagination-enabled {
 		.o-buttons-pagination {
+			display: flex;
+
 			> .o-buttons {
 				padding-left: 5px;
 				padding-right: 5px;
 				min-width: 24px;
+			}
 
-				&[disabled] {
-					visibility: hidden;
-				}
+			> .o-buttons[disabled] {
+				visibility: hidden;
+			}
 
-				&.o-buttons--big {
-					padding-left: 9px;
-					padding-right: 9px;
-					min-width: 36px;
-				}
+			> .o-buttons--big {
+				padding-left: 9px;
+				padding-right: 9px;
+				min-width: 36px;
+			}
+
+			> .o-buttons-pagination__ellipsis {
+				@include oTypographySans($scale: 1);
+				display: inline-block;
+				text-align: center;
+				min-width: 24px;
+			}
+
+			> .o-buttons-pagination__ellipsis--big {
+				@include oTypographySans($scale: 3);
+				min-width: 36px;
+			}
+
+			// Any child element preceded by another sibling element.
+			> * + * {
+				margin: 0 0 0 oSpacingByName('s1');
 			}
 		}
 	}

--- a/origami.json
+++ b/origami.json
@@ -99,6 +99,12 @@
 			"description": "This demo shows a pagination layout with anchor tags and the default theme. The number of pages to show and button theme may be chosen by the project."
 		},
 		{
+			"name": "pagination-size",
+			"title": "Pagination layout size",
+			"template": "/demos/src/pagination-size.mustache",
+			"description": "Pagination layouts may also use big buttons."
+		},
+		{
 			"name": "grouped",
 			"title": "Grouped layout",
 			"template": "/demos/src/grouped.mustache",


### PR DESCRIPTION
- Adds a new class `o-buttons-pagination__ellipsis`. Existing
markup, where the ellipsis is has no class, will not break. As
a new feature this needs a minor release.
- Adds guidance on how to implement pagination. `o-buttons` doesn't
enforce how many pages to show in pagination but now has
recommendations.

Fixes: https://github.com/Financial-Times/o-buttons/issues/278
Fixes: https://github.com/Financial-Times/o-buttons/issues/279

Old demo:
![Screenshot 2020-11-18 at 15 43 55](https://user-images.githubusercontent.com/10405691/99552413-e3f0e700-29b4-11eb-931a-620d00dbd6ed.png)

New demos:
![Screenshot 2020-11-18 at 15 41 27](https://user-images.githubusercontent.com/10405691/99552332-cae83600-29b4-11eb-8a23-7d160ff589cb.png)
![Screenshot 2020-11-18 at 15 41 24](https://user-images.githubusercontent.com/10405691/99552337-ccb1f980-29b4-11eb-87e0-874471d64d1d.png)
