### PR TITLE
Update padding to improve icon position (default button size)

### DIFF
--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -23,7 +23,7 @@ $_o-buttons-shared-brand-config: (
 	// The vertical padding magic number is calculated like this:
 	// ((min-height - line-height) / 2) - border-width
 	'padding': 6px 8px,
-	'icon-padding': 22px,
+	'icon-padding': 24px,
 	'big': (
 		'scale': 0,
 		'background-size': 40px,


### PR DESCRIPTION
before:
![Screenshot 2020-11-26 at 14 44 33](https://user-images.githubusercontent.com/10405691/100364521-29856380-2ff6-11eb-904d-1f0695c67874.png)

after:
![Screenshot 2020-11-26 at 14 44 45](https://user-images.githubusercontent.com/10405691/100364544-30ac7180-2ff6-11eb-87b5-cd53f0fac3ce.png)

fixes: https://github.com/Financial-Times/o-buttons/issues/284

In the future we hope to update our icons, so they work a little better together and have less whitespace built into the svg:
https://financialtimes.slack.com/archives/C01481FKWA2/p1606134850135300